### PR TITLE
[#63] feat: 예약 불가능 날짜 조회 구현

### DIFF
--- a/src/main/java/com/prgrms/amabnb/reservation/api/ReservationController.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/api/ReservationController.java
@@ -6,6 +6,8 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.amabnb.reservation.dto.request.ReservationDateRequest;
+import com.prgrms.amabnb.reservation.dto.response.ReservationDatesResponse;
 import com.prgrms.amabnb.reservation.dto.response.ReservationResponseForGuest;
 import com.prgrms.amabnb.reservation.service.ReservationService;
 import com.prgrms.amabnb.security.jwt.JwtAuthentication;
@@ -36,6 +40,14 @@ public class ReservationController {
         return ResponseEntity
             .created(uri)
             .body(response);
+    }
+
+    @GetMapping("/dates/{roomId}")
+    public ResponseEntity<ReservationDatesResponse> getReservationDates(
+        @PathVariable Long roomId,
+        ReservationDateRequest request
+    ) {
+        return ResponseEntity.ok(reservationService.getImpossibleReservationDates(roomId, request));
     }
 
     private URI generateUri(ReservationResponseForGuest response) {

--- a/src/main/java/com/prgrms/amabnb/reservation/dto/request/ReservationDateRequest.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/dto/request/ReservationDateRequest.java
@@ -1,0 +1,26 @@
+package com.prgrms.amabnb.reservation.dto.request;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReservationDateRequest {
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    public ReservationDateRequest(LocalDate startDate, LocalDate endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+}

--- a/src/main/java/com/prgrms/amabnb/reservation/dto/response/ReservationDateResponse.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/dto/response/ReservationDateResponse.java
@@ -1,0 +1,21 @@
+package com.prgrms.amabnb.reservation.dto.response;
+
+import java.time.LocalDate;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReservationDateResponse {
+
+    private LocalDate checkIn;
+    private LocalDate checkOut;
+
+    public ReservationDateResponse(LocalDate checkIn, LocalDate checkOut) {
+        this.checkIn = checkIn;
+        this.checkOut = checkOut.minusDays(1);
+    }
+
+}

--- a/src/main/java/com/prgrms/amabnb/reservation/dto/response/ReservationDatesResponse.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/dto/response/ReservationDatesResponse.java
@@ -1,0 +1,19 @@
+package com.prgrms.amabnb.reservation.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReservationDatesResponse {
+
+    private List<ReservationDateResponse> reservationDates;
+
+    public ReservationDatesResponse(List<ReservationDateResponse> reservationDates) {
+        this.reservationDates = reservationDates;
+    }
+
+}

--- a/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryCustom.java
@@ -1,5 +1,9 @@
 package com.prgrms.amabnb.reservation.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
 import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
 import com.prgrms.amabnb.room.entity.Room;
 import com.prgrms.amabnb.user.entity.User;
@@ -10,4 +14,5 @@ public interface ReservationRepositoryCustom {
 
     boolean existReservationByGuest(User guest, ReservationDate reservationDate);
 
+    List<ReservationDateResponse> findImpossibleReservationDate(Long roomId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryImpl.java
@@ -67,7 +67,6 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
             .where(reservation.room.id.eq(roomId),
                 notInCanceled(),
                 reservation.reservationDate.checkIn.between(startDate, endDate))
-            .orderBy(reservation.id.desc())
             .fetch();
     }
 

--- a/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryImpl.java
@@ -3,11 +3,14 @@ package com.prgrms.amabnb.reservation.repository;
 import static com.prgrms.amabnb.reservation.entity.QReservation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
 import com.prgrms.amabnb.reservation.entity.ReservationStatus;
 import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
 import com.prgrms.amabnb.room.entity.Room;
 import com.prgrms.amabnb.user.entity.User;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -49,6 +52,23 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
             .fetchFirst();
 
         return fetchOne != null;
+    }
+
+    @Override
+    public List<ReservationDateResponse> findImpossibleReservationDate(
+        Long roomId,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        return queryFactory.select(Projections.constructor(ReservationDateResponse.class,
+                reservation.reservationDate.checkIn,
+                reservation.reservationDate.checkOut))
+            .from(reservation)
+            .where(reservation.room.id.eq(roomId),
+                notInCanceled(),
+                reservation.reservationDate.checkIn.between(startDate, endDate))
+            .orderBy(reservation.id.desc())
+            .fetch();
     }
 
     private BooleanExpression notInCanceled() {

--- a/src/main/java/com/prgrms/amabnb/reservation/service/ReservationService.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/service/ReservationService.java
@@ -1,9 +1,13 @@
 package com.prgrms.amabnb.reservation.service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
 import com.prgrms.amabnb.reservation.dto.response.ReservationResponseForGuest;
 import com.prgrms.amabnb.reservation.entity.Reservation;
 import com.prgrms.amabnb.reservation.exception.AlreadyReservationRoomException;
@@ -36,6 +40,14 @@ public class ReservationService {
         isAlreadyReservedRoom(reservation);
         isAlreadyReservedGuest(reservation);
         return ReservationResponseForGuest.from(reservationRepository.save(reservation));
+    }
+
+    public List<ReservationDateResponse> getImpossibleReservationDates(
+        Long roomId,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        return reservationRepository.findImpossibleReservationDate(roomId, startDate, endDate);
     }
 
     private void isAlreadyReservedRoom(Reservation reservation) {

--- a/src/main/java/com/prgrms/amabnb/reservation/service/ReservationService.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/service/ReservationService.java
@@ -1,13 +1,11 @@
 package com.prgrms.amabnb.reservation.service;
 
-import java.time.LocalDate;
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
-import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
+import com.prgrms.amabnb.reservation.dto.request.ReservationDateRequest;
+import com.prgrms.amabnb.reservation.dto.response.ReservationDatesResponse;
 import com.prgrms.amabnb.reservation.dto.response.ReservationResponseForGuest;
 import com.prgrms.amabnb.reservation.entity.Reservation;
 import com.prgrms.amabnb.reservation.exception.AlreadyReservationRoomException;
@@ -42,12 +40,12 @@ public class ReservationService {
         return ReservationResponseForGuest.from(reservationRepository.save(reservation));
     }
 
-    public List<ReservationDateResponse> getImpossibleReservationDates(
-        Long roomId,
-        LocalDate startDate,
-        LocalDate endDate
-    ) {
-        return reservationRepository.findImpossibleReservationDate(roomId, startDate, endDate);
+    public ReservationDatesResponse getImpossibleReservationDates(Long roomId, ReservationDateRequest request) {
+        return new ReservationDatesResponse(reservationRepository.findImpossibleReservationDate(
+            roomId,
+            request.getStartDate(),
+            request.getEndDate()
+        ));
     }
 
     private void isAlreadyReservedRoom(Reservation reservation) {

--- a/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
@@ -101,8 +101,8 @@ class ReservationRepositoryTest extends RepositoryTest {
             () -> assertThat(result).hasSize(2),
             () -> assertThat(result).extracting("checkIn", "checkOut")
                 .containsExactly(
-                    tuple(now.plusDays(10L), now.plusDays(14L)),
-                    tuple(now, now.plusDays(4L))
+                    tuple(now, now.plusDays(4L)),
+                    tuple(now.plusDays(10L), now.plusDays(14L))
                 )
         );
     }

--- a/src/test/java/com/prgrms/amabnb/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/service/ReservationServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +14,8 @@ import com.prgrms.amabnb.common.vo.Email;
 import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.config.ApiTest;
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
-import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
+import com.prgrms.amabnb.reservation.dto.request.ReservationDateRequest;
+import com.prgrms.amabnb.reservation.dto.response.ReservationDatesResponse;
 import com.prgrms.amabnb.reservation.dto.response.ReservationResponseForGuest;
 import com.prgrms.amabnb.reservation.entity.ReservationStatus;
 import com.prgrms.amabnb.reservation.exception.AlreadyReservationRoomException;
@@ -158,19 +158,15 @@ class ReservationServiceTest extends ApiTest {
     @Test
     void getImpossibleReservationDates() {
         // given
-        CreateReservationRequest request = createReservationRequest(3, 30_000, roomId);
-        reservationService.createReservation(guestId, request);
+        reservationService.createReservation(guestId, createReservationRequest(3, 30_000, roomId));
+        ReservationDateRequest request = new ReservationDateRequest(LocalDate.now(), LocalDate.now().plusMonths(1L));
 
         // when
-        List<ReservationDateResponse> result = reservationService.getImpossibleReservationDates(
-            roomId,
-            LocalDate.now(),
-            LocalDate.now().plusMonths(1L)
-        );
+        ReservationDatesResponse result = reservationService.getImpossibleReservationDates(roomId, request);
 
         // then
-        assertThat(result).hasSize(1);
-        assertThat(result).extracting("checkIn", "checkOut")
+        assertThat(result.getReservationDates()).hasSize(1);
+        assertThat(result.getReservationDates()).extracting("checkIn", "checkOut")
             .containsExactly(tuple(LocalDate.now(), LocalDate.now().plusDays(2L)));
     }
 


### PR DESCRIPTION
## 개요
- 예약 불가능 날짜 조회 기능 

## 작업사항
- 예약 체크인 날짜가 조회 시작 날짜와 끝 날짜 사이에 있을 시 조회되게 하였습니다. 
- 예약 불가능 날짜 조회시 예약 날짜 - 1 을 하여 조회하도록 하였습니다. 
  - 체크아웃 날짜의 경우 다른 사람이 체크인을 할 수 있다고 생각하여 이렇게 했는데 어떻게 생각하시나요? 🤔 

## 질문 
- 위의 질문 하나 
- List 결과값의 경우 그냥 보내주게 되면 키값이 없이 보내지게 되는 데 괜찮은 지 궁금합니다. 
  - 일단 감싸는 DTO를 하나 만들어서 반환하였습니다. 
  - JPA 강의때처럼 ApiResponse를 하나 만드는 것도 좋아보입니다!
 
## 기타
- [노션 API 문서](https://www.notion.so/backend-devcourse/reservations-dates-roomId-startDate-endDate-ef31566a7e1c42d3a0b73962abcf063a)
- resolves #63 
