### PR TITLE
[#71] feat: 예약 정보 수정 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ dependencies {
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/com/prgrms/amabnb/common/vo/Money.java
+++ b/src/main/java/com/prgrms/amabnb/common/vo/Money.java
@@ -32,4 +32,8 @@ public class Money {
     public Money multiply(int period) {
         return new Money(this.value * period);
     }
+
+    public Money add(Money payment) {
+        return new Money(this.value + payment.value);
+    }
 }

--- a/src/main/java/com/prgrms/amabnb/reservation/api/ReservationGuestApi.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/api/ReservationGuestApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -18,6 +19,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import com.prgrms.amabnb.common.model.ApiResponse;
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.amabnb.reservation.dto.request.ReservationDateRequest;
+import com.prgrms.amabnb.reservation.dto.request.ReservationUpdateRequest;
 import com.prgrms.amabnb.reservation.dto.request.SearchReservationsRequest;
 import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
 import com.prgrms.amabnb.reservation.dto.response.ReservationResponseForGuest;
@@ -65,6 +67,15 @@ public class ReservationGuestApi {
         SearchReservationsRequest request
     ) {
         return ResponseEntity.ok(new ApiResponse<>(reservationGuestService.getReservations(user.id(), request)));
+    }
+
+    @PutMapping("/reservations/{reservationId}")
+    public ResponseEntity<ApiResponse<ReservationResponseForGuest>> modifyReservation(
+        @AuthenticationPrincipal JwtAuthentication user,
+        @PathVariable Long reservationId,
+        @Valid @RequestBody ReservationUpdateRequest request
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(reservationGuestService.modify(user.id(), reservationId, request)));
     }
 
     @DeleteMapping("/guest/reservations/{reservationId}")

--- a/src/main/java/com/prgrms/amabnb/reservation/dto/request/ReservationUpdateRequest.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/dto/request/ReservationUpdateRequest.java
@@ -1,0 +1,38 @@
+package com.prgrms.amabnb.reservation.dto.request;
+
+import java.time.LocalDate;
+
+import javax.validation.constraints.Future;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReservationUpdateRequest {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @NotNull(message = "체크아웃은 비어있을 수 없습니다.")
+    @Future(message = "체크아웃은 현재보다 전이거나 현재일 수 없습니다.")
+    private LocalDate checkOut;
+
+    @NotNull(message = "총 인원 수는 비어있을 수 없습니다.")
+    @Positive(message = "총 인원 수는 양수여야 합니다.")
+    private Integer totalGuest;
+
+    @NotNull(message = "추가 가격은 비어있을 수 없습니다.")
+    @Positive(message = "추가 가격은 양수여야 합니다.")
+    private Integer paymentPrice;
+
+    public ReservationUpdateRequest(LocalDate checkOut, Integer totalGuest, Integer paymentPrice) {
+        this.checkOut = checkOut;
+        this.totalGuest = totalGuest;
+        this.paymentPrice = paymentPrice;
+    }
+
+}

--- a/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
@@ -13,14 +13,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 
 import com.prgrms.amabnb.common.model.BaseEntity;
 import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
 import com.prgrms.amabnb.reservation.exception.ReservationInvalidValueException;
 import com.prgrms.amabnb.reservation.exception.ReservationStatusException;
-import com.prgrms.amabnb.review.entity.Review;
 import com.prgrms.amabnb.room.entity.Room;
 import com.prgrms.amabnb.user.entity.User;
 
@@ -59,10 +57,6 @@ public class Reservation extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
     private User guest;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id")
-    private Review review;
 
     @Builder
     public Reservation(

--- a/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
@@ -1,5 +1,7 @@
 package com.prgrms.amabnb.reservation.entity;
 
+import java.time.LocalDate;
+
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -11,12 +13,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 
 import com.prgrms.amabnb.common.model.BaseEntity;
 import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
 import com.prgrms.amabnb.reservation.exception.ReservationInvalidValueException;
 import com.prgrms.amabnb.reservation.exception.ReservationStatusException;
+import com.prgrms.amabnb.review.entity.Review;
 import com.prgrms.amabnb.room.entity.Room;
 import com.prgrms.amabnb.user.entity.User;
 
@@ -56,6 +60,10 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "users_id")
     private User guest;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
     @Builder
     public Reservation(
         Long id,
@@ -78,6 +86,15 @@ public class Reservation extends BaseEntity {
         this.id = id;
     }
 
+    public void modify(LocalDate checkOut, int totalGuest, Money payment) {
+        if (isNotModifiable()) {
+            throw new ReservationStatusException();
+        }
+        this.reservationDate = this.reservationDate.changeCheckOut(checkOut);
+        this.totalGuest = totalGuest;
+        this.totalPrice = this.totalPrice.add(payment);
+    }
+
     public boolean isNotHost(User user) {
         return !this.room.isHost(user);
     }
@@ -87,11 +104,11 @@ public class Reservation extends BaseEntity {
     }
 
     public boolean isNotValidatePrice() {
-        return !getRoom().isValidatePrice(totalPrice, reservationDate.getPeriod());
+        return !this.room.isValidatePrice(totalPrice, reservationDate.getPeriod());
     }
 
     public boolean isOverMaxGuest() {
-        return room.isOverMaxGuestNum(totalGuest);
+        return this.room.isOverMaxGuestNum(totalGuest);
     }
 
     public void changeStatus(ReservationStatus status) {
@@ -105,7 +122,7 @@ public class Reservation extends BaseEntity {
         return this.reservationStatus != ReservationStatus.PENDING;
     }
 
-    public void setReservationDate(ReservationDate reservationDate) {
+    private void setReservationDate(ReservationDate reservationDate) {
         if (reservationDate == null) {
             throw new ReservationInvalidValueException("예약 날짜는 비어있을 수 없습니다.");
         }

--- a/src/main/java/com/prgrms/amabnb/reservation/entity/vo/ReservationDate.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/entity/vo/ReservationDate.java
@@ -7,6 +7,7 @@ import javax.persistence.AccessType;
 import javax.persistence.Embeddable;
 
 import com.prgrms.amabnb.reservation.exception.ReservationInvalidValueException;
+import com.prgrms.amabnb.reservation.exception.ReservationReduceDateException;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -34,6 +35,13 @@ public class ReservationDate {
 
     public int getPeriod() {
         return checkIn.until(checkOut).getDays();
+    }
+
+    public ReservationDate changeCheckOut(LocalDate checkOut) {
+        if (this.checkOut.isAfter(checkOut)) {
+            throw new ReservationReduceDateException();
+        }
+        return new ReservationDate(this.checkIn, checkOut);
     }
 
     private void validateNull(LocalDate checkIn, LocalDate checkOut) {

--- a/src/main/java/com/prgrms/amabnb/reservation/exception/ReservationReduceDateException.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/exception/ReservationReduceDateException.java
@@ -1,0 +1,13 @@
+package com.prgrms.amabnb.reservation.exception;
+
+import com.prgrms.amabnb.common.exception.InvalidValueException;
+
+public class ReservationReduceDateException extends InvalidValueException {
+
+    private static final String MESSAGE = "예약 변경은 예약 연장시에만 가능합니다.";
+
+    public ReservationReduceDateException() {
+        super(MESSAGE);
+    }
+
+}

--- a/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryCustom.java
@@ -12,7 +12,7 @@ import com.prgrms.amabnb.user.entity.User;
 
 public interface ReservationRepositoryCustom {
 
-    boolean existReservationByRoom(Room room, ReservationDate reservationDate);
+    boolean existReservationByRoom(Room room, Long reservationId, ReservationDate reservationDate);
 
     List<ReservationDateResponse> findReservationDates(Long roomId, LocalDate startDate, LocalDate endDate);
 

--- a/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryImpl.java
@@ -27,7 +27,7 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public boolean existReservationByRoom(Room room, ReservationDate reservationDate) {
+    public boolean existReservationByRoom(Room room, Long reservationId, ReservationDate reservationDate) {
         LocalDate checkIn = reservationDate.getCheckIn();
         LocalDate checkOut = reservationDate.getCheckOut();
 
@@ -35,8 +35,9 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
             .from(reservation)
             .where(
                 eqRoom(room)
-                    .and(notInCanceled())
-                    .and(betweenCheckIn(checkIn, checkOut).or(betweenCheckOut(checkIn, checkOut)))
+                , notEqReservationId(reservationId)
+                , notInCanceled()
+                , betweenCheckIn(checkIn, checkOut).or(betweenCheckOut(checkIn, checkOut))
             )
             .fetchFirst();
 
@@ -160,6 +161,13 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
         }
 
         return Expressions.asEnum(status).as(reservation.reservationStatus);
+    }
+
+    private BooleanExpression notEqReservationId(Long id) {
+        if (id == null) {
+            return null;
+        }
+        return reservation.id.ne(id);
     }
 
 }

--- a/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
@@ -1,5 +1,22 @@
 package com.prgrms.amabnb.reservation.repository;
 
+import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
+import static java.time.LocalDate.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.prgrms.amabnb.common.vo.Email;
 import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.common.vo.PhoneNumber;
@@ -17,23 +34,6 @@ import com.prgrms.amabnb.room.repository.RoomRepository;
 import com.prgrms.amabnb.user.entity.User;
 import com.prgrms.amabnb.user.entity.UserRole;
 import com.prgrms.amabnb.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static com.prgrms.amabnb.reservation.entity.ReservationStatus.PENDING;
-import static java.time.LocalDate.now;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ReservationRepositoryTest extends RepositoryTest {
 
@@ -54,9 +54,9 @@ class ReservationRepositoryTest extends RepositoryTest {
 
     private static Stream<Arguments> provideReservationDate() {
         return Stream.of(
-                Arguments.of(now(), now().plusDays(3L), true),
-                Arguments.of(now().plusDays(5L), now().plusDays(10L), false),
-                Arguments.of(now().plusDays(5L), now().plusDays(10L), false)
+            Arguments.of(now(), now().plusDays(3L), true),
+            Arguments.of(now().plusDays(5L), now().plusDays(10L), false),
+            Arguments.of(now().plusDays(5L), now().plusDays(10L), false)
         );
     }
 
@@ -75,7 +75,7 @@ class ReservationRepositoryTest extends RepositoryTest {
         ReservationDate reservationDate = new ReservationDate(checkIn, checkOut);
 
         // when
-        boolean isExists = reservationRepository.existReservationByRoom(room, reservationDate);
+        boolean isExists = reservationRepository.existReservationByRoom(room, null, reservationDate);
 
         // then
         assertThat(isExists).isEqualTo(result);
@@ -92,16 +92,16 @@ class ReservationRepositoryTest extends RepositoryTest {
 
         // when
         List<ReservationDateResponse> result = reservationRepository.findReservationDates(room.getId(),
-                now, endDate);
+            now, endDate);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(2),
-                () -> assertThat(result).extracting("checkIn", "checkOut")
-                        .containsExactly(
-                                tuple(now, now.plusDays(4L)),
-                                tuple(now.plusDays(10L), now.plusDays(14L))
-                        )
+            () -> assertThat(result).hasSize(2),
+            () -> assertThat(result).extracting("checkIn", "checkOut")
+                .containsExactly(
+                    tuple(now, now.plusDays(4L)),
+                    tuple(now.plusDays(10L), now.plusDays(14L))
+                )
         );
     }
 
@@ -111,19 +111,19 @@ class ReservationRepositoryTest extends RepositoryTest {
         // give
         for (int i = 0; i < 100; i++) {
             reservationRepository.save(
-                    createReservation(guest, new ReservationDate(now().plusDays(i), now().plusDays(i + 1))));
+                createReservation(guest, new ReservationDate(now().plusDays(i), now().plusDays(i + 1))));
         }
         Long lastReservationId = null;
         int pageSize = 10;
 
         // when
         List<ReservationDto> reservations = reservationRepository.findReservationsByGuestAndStatus(
-                lastReservationId, pageSize, guest, PENDING);
+            lastReservationId, pageSize, guest, PENDING);
 
         // then
         assertAll(
-                () -> assertThat(reservations).hasSize(pageSize),
-                () -> assertThat(reservations).extracting("reservationStatus").containsOnly(PENDING)
+            () -> assertThat(reservations).hasSize(pageSize),
+            () -> assertThat(reservations).extracting("reservationStatus").containsOnly(PENDING)
         );
     }
 
@@ -133,14 +133,14 @@ class ReservationRepositoryTest extends RepositoryTest {
         // give
         for (int i = 0; i < 100; i++) {
             reservationRepository.save(
-                    createReservation(guest, new ReservationDate(now().plusDays(i), now().plusDays(i + 1))));
+                createReservation(guest, new ReservationDate(now().plusDays(i), now().plusDays(i + 1))));
         }
         Long lastReservationId = null;
         int pageSize = 10;
 
         // when
         List<ReservationDto> reservations = reservationRepository.findReservationsByHostAndStatus(
-                lastReservationId, pageSize, host, null);
+            lastReservationId, pageSize, host, null);
 
         // then
         assertThat(reservations).hasSize(pageSize);
@@ -148,51 +148,51 @@ class ReservationRepositoryTest extends RepositoryTest {
 
     private User createGuest() {
         User user = User.builder()
-                .oauthId("testOauthId")
-                .provider("testProvider")
-                .userRole(UserRole.GUEST)
-                .name("testUser")
-                .email(new Email("asdsadsad@gmail.com"))
-                .phoneNumber(new PhoneNumber("010-2312-1231"))
-                .profileImgUrl("urlurlrurlrurlurlurl")
-                .build();
+            .oauthId("testOauthId")
+            .provider("testProvider")
+            .userRole(UserRole.GUEST)
+            .name("testUser")
+            .email(new Email("asdsadsad@gmail.com"))
+            .phoneNumber(new PhoneNumber("010-2312-1231"))
+            .profileImgUrl("urlurlrurlrurlurlurl")
+            .build();
 
         return userRepository.save(user);
     }
 
     private Room createRoom() {
         host = User.builder()
-                .oauthId("testOauth")
-                .provider("testProvider")
-                .userRole(UserRole.GUEST)
-                .name("testUser")
-                .email(new Email("asdsadsasdad@gmail.com"))
-                .profileImgUrl("urlurlrurlrurlurlurl")
-                .build();
+            .oauthId("testOauth")
+            .provider("testProvider")
+            .userRole(UserRole.GUEST)
+            .name("testUser")
+            .email(new Email("asdsadsasdad@gmail.com"))
+            .profileImgUrl("urlurlrurlrurlurlurl")
+            .build();
         userRepository.save(host);
         Room room = Room.builder()
-                .name("별이 빛나는 밤")
-                .maxGuestNum(1)
-                .host(host)
-                .description("방 설명 입니다")
-                .address(new RoomAddress("00000", "창원", "의창구"))
-                .price(new Money(10_000))
-                .roomOption(new RoomOption(1, 1, 1))
-                .roomType(RoomType.APARTMENT)
-                .roomScope(RoomScope.PRIVATE)
-                .build();
+            .name("별이 빛나는 밤")
+            .maxGuestNum(1)
+            .host(host)
+            .description("방 설명 입니다")
+            .address(new RoomAddress("00000", "창원", "의창구"))
+            .price(new Money(10_000))
+            .roomOption(new RoomOption(1, 1, 1))
+            .roomType(RoomType.APARTMENT)
+            .roomScope(RoomScope.PRIVATE)
+            .build();
 
         return roomRepository.save(room);
     }
 
     private Reservation createReservation(User guest, ReservationDate reservationDate) {
         Reservation reservation = Reservation.builder()
-                .reservationDate(reservationDate)
-                .totalGuest(3)
-                .totalPrice(new Money(100_000))
-                .room(room)
-                .guest(guest)
-                .build();
+            .reservationDate(reservationDate)
+            .totalGuest(3)
+            .totalPrice(new Money(100_000))
+            .room(room)
+            .guest(guest)
+            .build();
 
         return reservationRepository.save(reservation);
     }


### PR DESCRIPTION
## 개요
- 게스트가 예약을 수정한다. 

## 작업사항
![image](https://user-images.githubusercontent.com/65746780/177110987-d3d78445-8426-45ad-bcde-304b845992e9.png)
- 예약 수정 
  - 예약 상태가 PENDING 일때만 가능
  - 수정하고 싶은 체크아웃 기간이 본래의 체크아웃보다 후일때 ( 예약 기간을 연장할 시)만 가능
  - 이후 생성할때의 검증로직을 거치게 됩니다. 

## 변경로직
![image](https://user-images.githubusercontent.com/65746780/177109454-d29a1200-77af-47fa-8cf5-99f0da9c4ea4.png)

- 원래 예약 검증 중에 룸만을 확인하였지만 수정시에도 똑같이 하면 본래 예약까지 확인해버려 절대 수정할 수 없게 됩니다.
- 그래서 `existReservationByRoom` 해당 메서드에 `reservationId`를 `!=`로 동적쿼리가 작동하도록 구현하였습니다. 

## 기타
- resolves #71 
