### PR TITLE
[#87] test: 통합테스트에서 @Transactional 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.google.guava:guava:31.1-jre'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/prgrms/amabnb/AmabnbApplication.java
+++ b/src/main/java/com/prgrms/amabnb/AmabnbApplication.java
@@ -2,9 +2,7 @@ package com.prgrms.amabnb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class AmabnbApplication {
 

--- a/src/main/java/com/prgrms/amabnb/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/prgrms/amabnb/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.prgrms.amabnb.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/prgrms/amabnb/reservation/dto/request/CreateReservationRequest.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/dto/request/CreateReservationRequest.java
@@ -1,5 +1,7 @@
 package com.prgrms.amabnb.reservation.dto.request;
 
+import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
+
 import java.time.LocalDate;
 
 import javax.validation.constraints.Future;
@@ -60,6 +62,7 @@ public class CreateReservationRequest {
             .reservationDate(new ReservationDate(checkIn, checkOut))
             .totalGuest(totalGuest)
             .totalPrice(new Money(totalPrice))
+            .reservationStatus(PENDING)
             .room(room)
             .guest(guest)
             .build();

--- a/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
@@ -65,6 +65,7 @@ public class Reservation extends BaseEntity {
         ReservationDate reservationDate,
         int totalGuest,
         Money totalPrice,
+        ReservationStatus reservationStatus,
         Room room,
         User guest
     ) {
@@ -74,7 +75,7 @@ public class Reservation extends BaseEntity {
         setTotalPrice(totalPrice);
         setRoom(room);
         setGuest(guest);
-        reservationStatus = ReservationStatus.PENDING;
+        setReservationStatus(reservationStatus);
     }
 
     public Reservation(Long id) {
@@ -150,5 +151,12 @@ public class Reservation extends BaseEntity {
             throw new ReservationInvalidValueException("게스트는 비어있을 수 없습니다.");
         }
         this.guest = guest;
+    }
+
+    private void setReservationStatus(ReservationStatus reservationStatus) {
+        if (reservationStatus == null) {
+            throw new ReservationInvalidValueException("예약 상태는 비어있을 수 없습니다.");
+        }
+        this.reservationStatus = reservationStatus;
     }
 }

--- a/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
+++ b/src/main/java/com/prgrms/amabnb/reservation/entity/Reservation.java
@@ -10,6 +10,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -35,7 +36,7 @@ public class Reservation extends BaseEntity {
     private static final int GUEST_MIN_VALUE = 1;
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Embedded

--- a/src/main/java/com/prgrms/amabnb/review/entity/Review.java
+++ b/src/main/java/com/prgrms/amabnb/review/entity/Review.java
@@ -3,6 +3,7 @@ package com.prgrms.amabnb.review.entity;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class Review extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String content;
     private int score;

--- a/src/main/java/com/prgrms/amabnb/room/entity/Room.java
+++ b/src/main/java/com/prgrms/amabnb/room/entity/Room.java
@@ -13,6 +13,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
@@ -40,7 +41,7 @@ public class Room extends BaseEntity {
     private static final int MAX_NAME_LENGTH = 255;
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/prgrms/amabnb/room/entity/RoomImage.java
+++ b/src/main/java/com/prgrms/amabnb/room/entity/RoomImage.java
@@ -3,6 +3,7 @@ package com.prgrms.amabnb.room.entity;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class RoomImage {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String imagePath;

--- a/src/main/java/com/prgrms/amabnb/token/entity/Token.java
+++ b/src/main/java/com/prgrms/amabnb/token/entity/Token.java
@@ -3,6 +3,7 @@ package com.prgrms.amabnb.token.entity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 import lombok.AccessLevel;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class Token {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/prgrms/amabnb/user/entity/User.java
+++ b/src/main/java/com/prgrms/amabnb/user/entity/User.java
@@ -9,6 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
@@ -31,7 +32,7 @@ public class User extends BaseEntity {
     private static final int NAME_MAX_LENGTH = 20;
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -5,7 +5,7 @@ spring:
   datasource:
     username: sa
     password:
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=MYSQL;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
 
   jpa:
@@ -14,10 +14,10 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQL5Dialect
         format_sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
 
   security:
     oauth2:

--- a/src/test/java/com/prgrms/amabnb/common/fixture/ReviewFixture.java
+++ b/src/test/java/com/prgrms/amabnb/common/fixture/ReviewFixture.java
@@ -1,5 +1,7 @@
 package com.prgrms.amabnb.common.fixture;
 
+import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
+
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -21,6 +23,7 @@ public class ReviewFixture {
             .reservationDate(new ReservationDate(LocalDate.now(), LocalDate.now().plusDays(3L)))
             .totalGuest(1)
             .totalPrice(new Money(1000))
+            .reservationStatus(PENDING)
             .room(room)
             .guest(guest)
             .build();

--- a/src/test/java/com/prgrms/amabnb/config/ApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/config/ApiTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,7 +15,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.restdocs.headers.RequestHeadersSnippet;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,7 +24,6 @@ import com.prgrms.amabnb.security.oauth.UserProfile;
 
 @Import(InfraConfig.class)
 @SpringBootTest
-@Transactional
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 public abstract class ApiTest {
@@ -41,6 +40,14 @@ public abstract class ApiTest {
 
     @Autowired
     protected OAuthService oAuthService;
+
+    @Autowired
+    protected DatabaseCleanup databaseCleanup;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanup.execute();
+    }
 
     protected RequestHeadersSnippet tokenRequestHeader() {
         return requestHeaders(

--- a/src/test/java/com/prgrms/amabnb/config/DatabaseCleanup.java
+++ b/src/test/java/com/prgrms/amabnb/config/DatabaseCleanup.java
@@ -1,0 +1,50 @@
+package com.prgrms.amabnb.config;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.base.CaseFormat;
+
+@Service
+@Profile("test")
+public class DatabaseCleanup implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        tableNames = entityManager.getMetamodel().getEntities().stream()
+            .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+            .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0;").executeUpdate();
+
+        for (String tableName : tableNames) {
+            if (tableName.equalsIgnoreCase("user")) {
+                tableName = "USERS";
+            }
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " AUTO_INCREMENT = 1").executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1;").executeUpdate();
+    }
+
+}

--- a/src/test/java/com/prgrms/amabnb/config/QueryConfig.java
+++ b/src/test/java/com/prgrms/amabnb/config/QueryConfig.java
@@ -5,9 +5,11 @@ import javax.persistence.PersistenceContext;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+@EnableJpaAuditing
 @TestConfiguration
 public class QueryConfig {
 

--- a/src/test/java/com/prgrms/amabnb/config/RepositoryTest.java
+++ b/src/test/java/com/prgrms/amabnb/config/RepositoryTest.java
@@ -1,9 +1,11 @@
 package com.prgrms.amabnb.config;
 
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
 @Import(QueryConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class RepositoryTest {
 }

--- a/src/test/java/com/prgrms/amabnb/reservation/api/ReservationGuestApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/api/ReservationGuestApiTest.java
@@ -171,7 +171,7 @@ class ReservationGuestApiTest extends ApiTest {
     void create_reservation_room_not_found() throws Exception {
         // given
         String accessToken = 로그인_요청(createUserProfile());
-        CreateReservationRequest request = createReservationRequest(10, 100_000, 1L);
+        CreateReservationRequest request = createReservationRequest(10, 100_000, 100L);
 
         // when
         MockHttpServletResponse response = 예약_요청(accessToken, request);

--- a/src/test/java/com/prgrms/amabnb/reservation/entity/ReservationTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/entity/ReservationTest.java
@@ -42,6 +42,7 @@ class ReservationTest {
             .totalGuest(totalGuest)
             .totalPrice(totalPrice)
             .reservationDate(reservationDate)
+            .reservationStatus(PENDING)
             .room(room)
             .guest(guest)
             .build();
@@ -141,6 +142,7 @@ class ReservationTest {
             .totalGuest(5)
             .totalPrice(new Money(10_000))
             .reservationDate(new ReservationDate(LocalDate.now(), LocalDate.now().plusDays(3L)))
+            .reservationStatus(PENDING)
             .room(room)
             .guest(user);
     }

--- a/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
@@ -190,6 +190,7 @@ class ReservationRepositoryTest extends RepositoryTest {
             .reservationDate(reservationDate)
             .totalGuest(3)
             .totalPrice(new Money(100_000))
+            .reservationStatus(PENDING)
             .room(room)
             .guest(guest)
             .build();

--- a/src/test/java/com/prgrms/amabnb/reservation/service/ReservationHostServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/service/ReservationHostServiceTest.java
@@ -156,6 +156,7 @@ class ReservationHostServiceTest extends ApiTest {
             .totalPrice(new Money(20_000))
             .totalGuest(1)
             .reservationDate(new ReservationDate(now(), now().plusDays(1L)))
+            .reservationStatus(PENDING)
             .build();
     }
 
@@ -163,6 +164,7 @@ class ReservationHostServiceTest extends ApiTest {
         return Reservation.builder()
             .room(room)
             .guest(guest)
+            .reservationStatus(PENDING)
             .totalPrice(new Money(20_000))
             .totalGuest(1)
             .reservationDate(new ReservationDate(now().plusDays(day), now().plusDays(day + 1)))

--- a/src/test/java/com/prgrms/amabnb/review/api/ReviewApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/review/api/ReviewApiTest.java
@@ -87,6 +87,7 @@ class ReviewApiTest extends ApiTest {
         @DisplayName("리뷰를 작성할 수 있다.")
         void postReview() throws Exception {
             givenReservation.changeStatus(ReservationStatus.COMPLETED);
+            reservationRepository.save(givenReservation);
 
             when_리뷰_작성(givenReservation.getId(), givenGuestAccessToken, givenReviewRequest)
                 .andExpect(status().isCreated())
@@ -101,6 +102,7 @@ class ReviewApiTest extends ApiTest {
         void exception1(ReservationStatus status) throws Exception {
             var errorMessage = "숙소 방문 완료 후 리뷰를 작성할 수 있습니다.";
             givenReservation.changeStatus(status);
+            reservationRepository.save(givenReservation);
 
             when_리뷰_작성(givenReservation.getId(), givenGuestAccessToken, givenReviewRequest)
                 .andExpect(status().isBadRequest())
@@ -114,6 +116,7 @@ class ReviewApiTest extends ApiTest {
             var errorMessage = "이미 작성한 예약 건 입니다.";
 
             givenReservation.changeStatus(ReservationStatus.COMPLETED);
+            reservationRepository.save(givenReservation);
 
             var firstReview = when_리뷰_작성(givenReservation.getId(), givenGuestAccessToken, givenReviewRequest);
             firstReview.andExpect(status().isCreated());
@@ -130,6 +133,7 @@ class ReviewApiTest extends ApiTest {
             var errorMessage = "예약자 본인만 리뷰를 작성할 수 있습니다.";
 
             givenReservation.changeStatus(ReservationStatus.COMPLETED);
+            reservationRepository.save(givenReservation);
 
             var illegalToken = 로그인_요청(createUserProfile("illegal"));
 

--- a/src/test/java/com/prgrms/amabnb/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/review/service/ReviewServiceTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.review.service;
 
+import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static com.prgrms.amabnb.review.service.ReviewServiceTest.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -19,7 +20,6 @@ import com.prgrms.amabnb.common.vo.Email;
 import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.reservation.dto.response.ReservationReviewResponse;
 import com.prgrms.amabnb.reservation.entity.Reservation;
-import com.prgrms.amabnb.reservation.entity.ReservationStatus;
 import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
 import com.prgrms.amabnb.reservation.service.ReservationGuestService;
 import com.prgrms.amabnb.review.dto.request.CreateReviewRequest;
@@ -63,6 +63,7 @@ class ReviewServiceTest {
                 .reservationDate(new ReservationDate(LocalDate.now(), LocalDate.now().plusDays(3L)))
                 .totalGuest(1)
                 .totalPrice(new Money(1000))
+                .reservationStatus(PENDING)
                 .room(room)
                 .guest(guest)
                 .build();
@@ -95,7 +96,7 @@ class ReviewServiceTest {
         @Test
         @DisplayName("리뷰를 작성한다")
         void createUserReview() {
-            givenReservation.changeStatus(ReservationStatus.COMPLETED);
+            givenReservation.changeStatus(COMPLETED);
             var givenReservationDto = ReservationReviewResponse.from(givenReservation);
             var givenReview = new Review(1L, "content", 2, givenReservation);
             var givenRequestDto = new CreateReviewRequest("content", 2);
@@ -122,7 +123,7 @@ class ReviewServiceTest {
         @Test
         @DisplayName("리뷰를 삭제한다")
         void deleteUserReview() {
-            givenReservation.changeStatus(ReservationStatus.COMPLETED);
+            givenReservation.changeStatus(COMPLETED);
             var givenReview = new Review(1L, "content", 2, givenReservation);
             var reservationDto = new ReservationReviewResponse(givenReservation.getId(),
                 givenReservation.getReservationStatus(), givenGuest.getId());


### PR DESCRIPTION
## 개요
- 통합테스트(ApiTest)에서 @Transactional 제거 

## 작업사항
- 실제 쿼리 확인과 실제 실행 환경처럼 진행하기 위해 제거 
  - 참고 : [JPA 사용시 테스트 코드에서 @Transactional 주의하기](https://javabom.tistory.com/103)
-   `@Transactional ` 대신 DatabaseCleanup 클래스 구현 
  - 참고 : [인수테스트에서 테스트 격리하기](https://tecoble.techcourse.co.kr/post/2020-09-15-test-isolation/) 

## 변경로직
- h2를 MySql 모드로 변경하여 기본키 전략을 IDENTITY로 변경하였습니다.
  - 이번에 RDS를 사용하니 미리 바꿔도 될 것 같아 변경하였습니다.  
- 혹시 문제가 될까 main에 있는 `@EnableJpaAuditing`를 분리하여 등록하도록 하였습니다!

## 질문 
- `@DataJpaTest` 이후 `@SpringBootTest`를 진행할 때 아마 db 에러가 뜰 건데 돌아가긴 합니다 
- 아마 다시 DDL을 create 할려고 해서 그런것 같은데 해결법 아시는 분 공유부탁드립니다!! 

## 기타
resolves #87 
