### PR TITLE
[#48] test : 중복되는 fixture 정리

### DIFF
--- a/src/test/java/com/prgrms/amabnb/config/ApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/config/ApiTest.java
@@ -1,7 +1,10 @@
 package com.prgrms.amabnb.config;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -12,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.restdocs.headers.RequestHeadersSnippet;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,6 +23,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.amabnb.common.exception.ErrorResponse;
+import com.prgrms.amabnb.config.util.DatabaseCleanup;
+import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
+import com.prgrms.amabnb.room.dto.request.CreateRoomRequest;
 import com.prgrms.amabnb.security.oauth.OAuthService;
 import com.prgrms.amabnb.security.oauth.UserProfile;
 
@@ -57,6 +64,34 @@ public abstract class ApiTest {
 
     protected String 로그인_요청(UserProfile userProfile) {
         return "Bearer" + oAuthService.register(userProfile).accessToken();
+    }
+
+    protected String 로그인_요청(String name) {
+        return "Bearer" + oAuthService.register(createUserProfile(name)).accessToken();
+    }
+
+    protected MockHttpServletResponse 예약_요청(String accessToken, CreateReservationRequest request) throws Exception {
+        return mockMvc.perform(post("/reservations")
+                .header(AUTHORIZATION, accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andReturn().getResponse();
+    }
+
+    protected Long 숙소_등록(String accessToken, CreateRoomRequest request) throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(post("/host/rooms")
+                .header(AUTHORIZATION, accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andReturn().getResponse();
+
+        return extractId(response);
+    }
+
+    protected Long extractId(MockHttpServletResponse response) {
+        String[] locations = response.getHeader("Location").split("/");
+        return Long.valueOf(locations[locations.length - 1]);
     }
 
     protected ErrorResponse extractErrorResponse(MockHttpServletResponse response) throws IOException {

--- a/src/test/java/com/prgrms/amabnb/config/util/DatabaseCleanup.java
+++ b/src/test/java/com/prgrms/amabnb/config/util/DatabaseCleanup.java
@@ -1,4 +1,4 @@
-package com.prgrms.amabnb.config;
+package com.prgrms.amabnb.config.util;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/test/java/com/prgrms/amabnb/config/util/Fixture.java
+++ b/src/test/java/com/prgrms/amabnb/config/util/Fixture.java
@@ -1,0 +1,102 @@
+package com.prgrms.amabnb.config.util;
+
+import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
+import static com.prgrms.amabnb.user.entity.UserRole.*;
+import static java.time.LocalDate.*;
+
+import java.util.List;
+
+import com.prgrms.amabnb.common.vo.Email;
+import com.prgrms.amabnb.common.vo.Money;
+import com.prgrms.amabnb.reservation.entity.Reservation;
+import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
+import com.prgrms.amabnb.room.dto.request.CreateRoomRequest;
+import com.prgrms.amabnb.room.entity.Room;
+import com.prgrms.amabnb.room.entity.RoomImage;
+import com.prgrms.amabnb.room.entity.RoomScope;
+import com.prgrms.amabnb.room.entity.RoomType;
+import com.prgrms.amabnb.room.entity.vo.RoomAddress;
+import com.prgrms.amabnb.room.entity.vo.RoomOption;
+import com.prgrms.amabnb.security.oauth.UserProfile;
+import com.prgrms.amabnb.user.entity.User;
+
+public class Fixture {
+
+    public static UserProfile createUserProfile(String name) {
+        return UserProfile.builder()
+            .oauthId(name)
+            .provider("kakao")
+            .name(name)
+            .email(name + "@gmail.com")
+            .profileImgUrl("url")
+            .build();
+    }
+
+    public static User createUser(String name) {
+        return User.builder()
+            .oauthId(name)
+            .provider("kakao")
+            .name(name)
+            .email(new Email(name + "@gmail.com"))
+            .userRole(GUEST)
+            .profileImgUrl("url")
+            .build();
+    }
+
+    public static User createUserWithId(String name) {
+        return User.builder()
+            .id(1L)
+            .oauthId(name)
+            .provider("kakao")
+            .name(name)
+            .email(new Email(name + "@gmail.com"))
+            .userRole(GUEST)
+            .profileImgUrl("url")
+            .build();
+    }
+
+    public static Room createRoom(User host) {
+        return Room.builder()
+            .name("별이 빛나는 밤")
+            .maxGuestNum(10)
+            .host(host)
+            .description("방 설명 입니다")
+            .address(new RoomAddress("00000", "창원", "의창구"))
+            .price(new Money(10_000))
+            .roomOption(new RoomOption(1, 1, 1))
+            .roomType(RoomType.APARTMENT)
+            .roomScope(RoomScope.PRIVATE)
+            .roomImages(List.of(new RoomImage("image")))
+            .build();
+    }
+
+    public static Reservation createReservation(Room room, User guest) {
+        return Reservation.builder()
+            .room(room)
+            .guest(guest)
+            .totalPrice(room.getPrice())
+            .totalGuest(1)
+            .reservationDate(new ReservationDate(now(), now().plusDays(1L)))
+            .reservationStatus(PENDING)
+            .build();
+    }
+
+    public static CreateRoomRequest createRoomRequest() {
+        return CreateRoomRequest.builder()
+            .name("별빛밤")
+            .price(100_000)
+            .description("방설명")
+            .maxGuestNum(10)
+            .zipcode("00000")
+            .address("창원")
+            .detailAddress("의창구")
+            .bedCnt(2)
+            .bedRoomCnt(1)
+            .bathRoomCnt(1)
+            .roomType(RoomType.APARTMENT)
+            .roomScope(RoomScope.PRIVATE)
+            .imagePaths(List.of("test"))
+            .build();
+    }
+
+}

--- a/src/test/java/com/prgrms/amabnb/reservation/api/ReservationGuestApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/api/ReservationGuestApiTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.reservation.api;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static java.time.LocalDate.*;
 import static org.assertj.core.api.Assertions.*;
@@ -37,28 +38,21 @@ import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.amabnb.reservation.dto.request.ReservationUpdateRequest;
 import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
 import com.prgrms.amabnb.reservation.dto.response.ReservationResponseForGuest;
-import com.prgrms.amabnb.room.dto.request.CreateRoomRequest;
-import com.prgrms.amabnb.room.entity.RoomScope;
-import com.prgrms.amabnb.room.entity.RoomType;
-import com.prgrms.amabnb.security.oauth.UserProfile;
 
 class ReservationGuestApiTest extends ApiTest {
 
     private Long roomId;
 
-    private String hostAccessToken;
-
     @BeforeEach
     void setUp() throws Exception {
-        hostAccessToken = 로그인_요청(createHostProfile());
-        roomId = 숙소_등록(hostAccessToken, createRoomRequest("별빛밤"));
+        roomId = 숙소_등록(로그인_요청("host"), createRoomRequest());
     }
 
     @DisplayName("유저는 숙소를 예약할 수 있다. 201 - CREATED")
     @Test
     void create_reservation() throws Exception {
         // given
-        String accessToken = 로그인_요청(createUserProfile());
+        String accessToken = 로그인_요청("guest");
         CreateReservationRequest request = createReservationRequest(1, 300_000, roomId);
 
         // when
@@ -116,7 +110,7 @@ class ReservationGuestApiTest extends ApiTest {
     @Test
     void create_reservation_over_max_guest_num() throws Exception {
         // given
-        String accessToken = 로그인_요청(createUserProfile());
+        String accessToken = 로그인_요청("guest");
         CreateReservationRequest request = createReservationRequest(100, 300_000, roomId);
 
         // when
@@ -133,7 +127,7 @@ class ReservationGuestApiTest extends ApiTest {
     @DisplayName("숙소 가격이 일치하지 않으면 예약할 수 없다. 400 - BAD REQUEST")
     @Test
     void xcreate_reservation_invalid_price() throws Exception {
-        String accessToken = 로그인_요청(createUserProfile());
+        String accessToken = 로그인_요청("guest");
         CreateReservationRequest request = createReservationRequest(1, 200_000, roomId);
 
         // when
@@ -151,9 +145,9 @@ class ReservationGuestApiTest extends ApiTest {
     @Test
     void create_reservation_already_reserved_room() throws Exception {
         CreateReservationRequest request = createReservationRequest(3, 300_000, roomId);
-        예약_요청(로그인_요청(createSpancerProfile()), request);
+        예약_요청(로그인_요청("test"), request);
 
-        String accessToken = 로그인_요청(createUserProfile());
+        String accessToken = 로그인_요청("guest");
 
         // when
         MockHttpServletResponse response = 예약_요청(accessToken, request);
@@ -170,7 +164,7 @@ class ReservationGuestApiTest extends ApiTest {
     @Test
     void create_reservation_room_not_found() throws Exception {
         // given
-        String accessToken = 로그인_요청(createUserProfile());
+        String accessToken = 로그인_요청("guest");
         CreateReservationRequest request = createReservationRequest(10, 100_000, 100L);
 
         // when
@@ -188,7 +182,7 @@ class ReservationGuestApiTest extends ApiTest {
     @Test
     void getReservationDates() throws Exception {
         // given
-        String accessToken = 로그인_요청(createSpancerProfile());
+        String accessToken = 로그인_요청("guest");
         LocalDate now = now();
         예약_요청(accessToken, createReservationRequest(3, 300_000, roomId));
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -231,9 +225,9 @@ class ReservationGuestApiTest extends ApiTest {
     @DisplayName("게스트가 예약을 취소한다. 204 - NO CONTENT")
     @Test
     void cancelByGuest() throws Exception {
-        String accessToken = 로그인_요청(createSpancerProfile());
+        String accessToken = 로그인_요청("guest");
         MockHttpServletResponse reservationResponse = 예약_요청(accessToken, createReservationRequest(3, 300_000, roomId));
-        Long reservationId = getReservationId(reservationResponse);
+        Long reservationId = extractReservationId(reservationResponse);
 
         // when
         MockHttpServletResponse response = mockMvc.perform(delete("/guest/reservations/{reservationId}", reservationId)
@@ -255,9 +249,9 @@ class ReservationGuestApiTest extends ApiTest {
     @Test
     void getReservation() throws Exception {
         // given
-        String accessToken = 로그인_요청(createSpancerProfile());
+        String accessToken = 로그인_요청("guest");
         MockHttpServletResponse reservationResponse = 예약_요청(accessToken, createReservationRequest(3, 300_000, roomId));
-        Long reservationId = getReservationId(reservationResponse);
+        Long reservationId = extractReservationId(reservationResponse);
 
         // when
         mockMvc.perform(get("/guest/reservations/{reservationId}", reservationId)
@@ -286,7 +280,7 @@ class ReservationGuestApiTest extends ApiTest {
     @Test
     void getReservations() throws Exception {
         // given
-        String accessToken = 로그인_요청(createSpancerProfile());
+        String accessToken = 로그인_요청("guest");
         for (int i = 0; i < 2; i++) {
             예약_요청(accessToken, createReservationRequestByDay(i));
         }
@@ -340,9 +334,9 @@ class ReservationGuestApiTest extends ApiTest {
     @Test
     void modifyReservation() throws Exception {
         // given
-        String accessToken = 로그인_요청(createUserProfile());
+        String accessToken = 로그인_요청("guest");
         MockHttpServletResponse reservationResponse = 예약_요청(accessToken, createReservationRequest(3, 300_000, roomId));
-        Long reservationId = getReservationId(reservationResponse);
+        Long reservationId = extractReservationId(reservationResponse);
         ReservationUpdateRequest request = new ReservationUpdateRequest(now().plusDays(5L), 5, 200_000);
 
         // when
@@ -374,78 +368,6 @@ class ReservationGuestApiTest extends ApiTest {
                 responseFields(
                     getReservationResponseForGuestDescriptor()
                 )));
-    }
-
-    private Long getReservationId(MockHttpServletResponse response) {
-        String[] locations = response.getHeader("Location").split("/");
-        return Long.valueOf(locations[locations.length - 1]);
-    }
-
-    private MockHttpServletResponse 예약_요청(String accessToken, CreateReservationRequest request) throws Exception {
-        return mockMvc.perform(post("/reservations")
-                .header(AUTHORIZATION, accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andDo(print())
-            .andReturn().getResponse();
-    }
-
-    private Long 숙소_등록(String accessToken, CreateRoomRequest request) throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(post("/host/rooms")
-                .header(AUTHORIZATION, accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andReturn().getResponse();
-
-        return getReservationId(response);
-    }
-
-    private UserProfile createUserProfile() {
-        return UserProfile.builder()
-            .oauthId("1")
-            .provider("kakao")
-            .name("아만드")
-            .email("asdasd@gmail.com")
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private UserProfile createHostProfile() {
-        return UserProfile.builder()
-            .oauthId("2")
-            .provider("host")
-            .name("아만드")
-            .email("host@gmail.com")
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private UserProfile createSpancerProfile() {
-        return UserProfile.builder()
-            .oauthId("3")
-            .provider("kakao")
-            .name("스펜서")
-            .email("spancer@gmail.com")
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private CreateRoomRequest createRoomRequest(String name) {
-        return CreateRoomRequest.builder()
-            .name(name)
-            .price(100_000)
-            .description("방설명")
-            .maxGuestNum(10)
-            .zipcode("00000")
-            .address("창원")
-            .detailAddress("의창구")
-            .bedCnt(2)
-            .bedRoomCnt(1)
-            .bathRoomCnt(1)
-            .roomType(RoomType.APARTMENT)
-            .roomScope(RoomScope.PRIVATE)
-            .imagePaths(List.of("test"))
-            .build();
     }
 
     private CreateReservationRequest createReservationRequest(int totalGuest, int totalPrice, Long roomId) {

--- a/src/test/java/com/prgrms/amabnb/reservation/api/ReservationGuestApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/api/ReservationGuestApiTest.java
@@ -227,7 +227,7 @@ class ReservationGuestApiTest extends ApiTest {
     void cancelByGuest() throws Exception {
         String accessToken = 로그인_요청("guest");
         MockHttpServletResponse reservationResponse = 예약_요청(accessToken, createReservationRequest(3, 300_000, roomId));
-        Long reservationId = extractReservationId(reservationResponse);
+        Long reservationId = extractId(reservationResponse);
 
         // when
         MockHttpServletResponse response = mockMvc.perform(delete("/guest/reservations/{reservationId}", reservationId)
@@ -251,7 +251,7 @@ class ReservationGuestApiTest extends ApiTest {
         // given
         String accessToken = 로그인_요청("guest");
         MockHttpServletResponse reservationResponse = 예약_요청(accessToken, createReservationRequest(3, 300_000, roomId));
-        Long reservationId = extractReservationId(reservationResponse);
+        Long reservationId = extractId(reservationResponse);
 
         // when
         mockMvc.perform(get("/guest/reservations/{reservationId}", reservationId)
@@ -336,7 +336,7 @@ class ReservationGuestApiTest extends ApiTest {
         // given
         String accessToken = 로그인_요청("guest");
         MockHttpServletResponse reservationResponse = 예약_요청(accessToken, createReservationRequest(3, 300_000, roomId));
-        Long reservationId = extractReservationId(reservationResponse);
+        Long reservationId = extractId(reservationResponse);
         ReservationUpdateRequest request = new ReservationUpdateRequest(now().plusDays(5L), 5, 200_000);
 
         // when

--- a/src/test/java/com/prgrms/amabnb/reservation/api/ReservationHostApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/api/ReservationHostApiTest.java
@@ -48,7 +48,7 @@ class ReservationHostApiTest extends ApiTest {
         // given
         MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청("guest"),
             createReservationRequest(3, 300_000, roomId));
-        Long reservationId = extractReservationId(ReservationResponseForGuest);
+        Long reservationId = extractId(ReservationResponseForGuest);
 
         // when
         MockHttpServletResponse response = mockMvc.perform(put("/host/reservations/{reservationId}", reservationId)
@@ -86,7 +86,7 @@ class ReservationHostApiTest extends ApiTest {
         // given
         MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청("guest"),
             createReservationRequest(3, 300_000, roomId));
-        Long reservationId = extractReservationId(ReservationResponseForGuest);
+        Long reservationId = extractId(ReservationResponseForGuest);
 
         // when
         MockHttpServletResponse response = mockMvc.perform(delete("/host/reservations/{reservationId}", reservationId)
@@ -110,7 +110,7 @@ class ReservationHostApiTest extends ApiTest {
         // given
         MockHttpServletResponse createResponse = 예약_요청(로그인_요청("guest"),
             createReservationRequest(3, 300_000, roomId));
-        Long reservationId = extractReservationId(createResponse);
+        Long reservationId = extractId(createResponse);
 
         // when
         mockMvc.perform(get("/host/reservations/{reservationId}", reservationId)

--- a/src/test/java/com/prgrms/amabnb/reservation/api/ReservationHostApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/api/ReservationHostApiTest.java
@@ -1,11 +1,11 @@
 package com.prgrms.amabnb.reservation.api;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static java.time.LocalDate.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -14,7 +14,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,10 +29,6 @@ import com.prgrms.amabnb.common.model.ApiResponse;
 import com.prgrms.amabnb.config.ApiTest;
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.amabnb.reservation.dto.response.ReservationInfoResponse;
-import com.prgrms.amabnb.room.dto.request.CreateRoomRequest;
-import com.prgrms.amabnb.room.entity.RoomScope;
-import com.prgrms.amabnb.room.entity.RoomType;
-import com.prgrms.amabnb.security.oauth.UserProfile;
 
 class ReservationHostApiTest extends ApiTest {
 
@@ -43,17 +38,17 @@ class ReservationHostApiTest extends ApiTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        hostAccessToken = 로그인_요청(createHostProfile());
-        roomId = 숙소_등록(hostAccessToken, createRoomRequest("별빛밤"));
+        hostAccessToken = 로그인_요청("host");
+        roomId = 숙소_등록(hostAccessToken, createRoomRequest());
     }
 
     @DisplayName("호스트가 예약을 승인한다. 200 - OK")
     @Test
     void approveReservation() throws Exception {
         // given
-        MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청(createSpancerProfile()),
+        MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청("guest"),
             createReservationRequest(3, 300_000, roomId));
-        Long reservationId = getReservationId(ReservationResponseForGuest);
+        Long reservationId = extractReservationId(ReservationResponseForGuest);
 
         // when
         MockHttpServletResponse response = mockMvc.perform(put("/host/reservations/{reservationId}", reservationId)
@@ -89,9 +84,9 @@ class ReservationHostApiTest extends ApiTest {
     @Test
     void cancelByHost() throws Exception {
         // given
-        MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청(createSpancerProfile()),
+        MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청("guest"),
             createReservationRequest(3, 300_000, roomId));
-        Long reservationId = getReservationId(ReservationResponseForGuest);
+        Long reservationId = extractReservationId(ReservationResponseForGuest);
 
         // when
         MockHttpServletResponse response = mockMvc.perform(delete("/host/reservations/{reservationId}", reservationId)
@@ -113,9 +108,9 @@ class ReservationHostApiTest extends ApiTest {
     @Test
     void getReservation() throws Exception {
         // given
-        MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청(createSpancerProfile()),
+        MockHttpServletResponse createResponse = 예약_요청(로그인_요청("guest"),
             createReservationRequest(3, 300_000, roomId));
-        Long reservationId = getReservationId(ReservationResponseForGuest);
+        Long reservationId = extractReservationId(createResponse);
 
         // when
         mockMvc.perform(get("/host/reservations/{reservationId}", reservationId)
@@ -163,7 +158,7 @@ class ReservationHostApiTest extends ApiTest {
     @Test
     void getReservations() throws Exception {
         // given
-        String accessToken = 로그인_요청(createSpancerProfile());
+        String accessToken = 로그인_요청("guest");
         for (int i = 0; i < 2; i++) {
             예약_요청(accessToken, createReservationRequestByDay(i));
         }
@@ -211,69 +206,6 @@ class ReservationHostApiTest extends ApiTest {
                     fieldWithPath("data[].guest.name").type(JsonFieldType.STRING).description("게스트 이름"),
                     fieldWithPath("data[].guest.email").type(JsonFieldType.STRING).description("게스트 이메일")
                 )));
-    }
-
-    private Long getReservationId(MockHttpServletResponse response) {
-        String[] locations = response.getHeader("Location").split("/");
-        return Long.valueOf(locations[locations.length - 1]);
-    }
-
-    private MockHttpServletResponse 예약_요청(String accessToken, CreateReservationRequest request) throws Exception {
-        return mockMvc.perform(post("/reservations")
-                .header(AUTHORIZATION, accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andDo(print())
-            .andReturn().getResponse();
-    }
-
-    private Long 숙소_등록(String accessToken, CreateRoomRequest request) throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(post("/host/rooms")
-                .header(AUTHORIZATION, accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andReturn().getResponse();
-
-        String[] location = response.getHeader("Location").split("/");
-        return Long.valueOf(location[location.length - 1]);
-    }
-
-    private UserProfile createHostProfile() {
-        return UserProfile.builder()
-            .oauthId("2")
-            .provider("host")
-            .name("아만드")
-            .email("host@gmail.com")
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private UserProfile createSpancerProfile() {
-        return UserProfile.builder()
-            .oauthId("3")
-            .provider("kakao")
-            .name("스펜서")
-            .email("spancer@gmail.com")
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private CreateRoomRequest createRoomRequest(String name) {
-        return CreateRoomRequest.builder()
-            .name(name)
-            .price(100_000)
-            .description("방설명")
-            .maxGuestNum(10)
-            .zipcode("00000")
-            .address("창원")
-            .detailAddress("의창구")
-            .bedCnt(2)
-            .bedRoomCnt(1)
-            .bathRoomCnt(1)
-            .roomType(RoomType.APARTMENT)
-            .roomScope(RoomScope.PRIVATE)
-            .imagePaths(List.of("test"))
-            .build();
     }
 
     private CreateReservationRequest createReservationRequest(int totalGuest, int totalPrice, Long roomId) {

--- a/src/test/java/com/prgrms/amabnb/reservation/entity/ReservationTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/entity/ReservationTest.java
@@ -1,11 +1,11 @@
 package com.prgrms.amabnb.reservation.entity;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,19 +13,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import com.prgrms.amabnb.common.vo.Email;
 import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
 import com.prgrms.amabnb.reservation.exception.ReservationInvalidValueException;
 import com.prgrms.amabnb.reservation.exception.ReservationStatusException;
 import com.prgrms.amabnb.room.entity.Room;
-import com.prgrms.amabnb.room.entity.RoomImage;
-import com.prgrms.amabnb.room.entity.RoomScope;
-import com.prgrms.amabnb.room.entity.RoomType;
-import com.prgrms.amabnb.room.entity.vo.RoomAddress;
-import com.prgrms.amabnb.room.entity.vo.RoomOption;
 import com.prgrms.amabnb.user.entity.User;
-import com.prgrms.amabnb.user.entity.UserRole;
 
 class ReservationTest {
 
@@ -36,7 +29,7 @@ class ReservationTest {
         int totalGuest = 5;
         Money totalPrice = new Money(10_000);
         ReservationDate reservationDate = new ReservationDate(LocalDate.now(), LocalDate.now().plusDays(3L));
-        Room room = createRoom();
+        Room room = createRoom(createUser("host"));
         User guest = createUser("guest");
 
         // when
@@ -137,7 +130,7 @@ class ReservationTest {
     }
 
     private Reservation.ReservationBuilder createReservationBuilder() {
-        Room room = createRoom();
+        Room room = createRoom(createUser("host"));
         User user = createUser("guest");
 
         return Reservation.builder()
@@ -147,35 +140,6 @@ class ReservationTest {
             .reservationStatus(PENDING)
             .room(room)
             .guest(user);
-    }
-
-    private Room createRoom() {
-        return Room.builder()
-            .name("별이 빛나는 밤")
-            .maxGuestNum(1)
-            .description("방 설명 입니다")
-            .address(new RoomAddress("00000", "창원", "의창구"))
-            .price(new Money(1_000))
-            .roomOption(new RoomOption(1, 1, 1))
-            .roomType(RoomType.APARTMENT)
-            .roomScope(RoomScope.PRIVATE)
-            .roomImages(List.of(createRoomImage()))
-            .build();
-    }
-
-    private RoomImage createRoomImage() {
-        return new RoomImage("aaa");
-    }
-
-    private User createUser(String name) {
-        return User.builder()
-            .oauthId(name)
-            .provider(name)
-            .userRole(UserRole.GUEST)
-            .name(name)
-            .email(new Email(name + "@gmail.com"))
-            .profileImgUrl("urlurlrurlrurlurlurl")
-            .build();
     }
 
 }

--- a/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/repository/ReservationRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.reservation.repository;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static java.time.LocalDate.*;
 import static org.assertj.core.api.Assertions.*;
@@ -17,23 +18,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.prgrms.amabnb.common.vo.Email;
 import com.prgrms.amabnb.common.vo.Money;
-import com.prgrms.amabnb.common.vo.PhoneNumber;
 import com.prgrms.amabnb.config.RepositoryTest;
 import com.prgrms.amabnb.reservation.dto.response.ReservationDateResponse;
 import com.prgrms.amabnb.reservation.dto.response.ReservationDto;
 import com.prgrms.amabnb.reservation.entity.Reservation;
 import com.prgrms.amabnb.reservation.entity.vo.ReservationDate;
 import com.prgrms.amabnb.room.entity.Room;
-import com.prgrms.amabnb.room.entity.RoomImage;
-import com.prgrms.amabnb.room.entity.RoomScope;
-import com.prgrms.amabnb.room.entity.RoomType;
-import com.prgrms.amabnb.room.entity.vo.RoomAddress;
-import com.prgrms.amabnb.room.entity.vo.RoomOption;
 import com.prgrms.amabnb.room.repository.RoomRepository;
 import com.prgrms.amabnb.user.entity.User;
-import com.prgrms.amabnb.user.entity.UserRole;
 import com.prgrms.amabnb.user.repository.UserRepository;
 
 class ReservationRepositoryTest extends RepositoryTest {
@@ -63,8 +56,9 @@ class ReservationRepositoryTest extends RepositoryTest {
 
     @BeforeEach
     void setUp() {
-        room = createRoom();
-        guest = createGuest();
+        host = userRepository.save(createUser("host"));
+        room = roomRepository.save(createRoom(host));
+        guest = userRepository.save(createUser("guest"));
         createReservation(guest, new ReservationDate(now(), now().plusDays(5L)));
     }
 
@@ -145,50 +139,6 @@ class ReservationRepositoryTest extends RepositoryTest {
 
         // then
         assertThat(reservations).hasSize(pageSize);
-    }
-
-    private User createGuest() {
-        User user = User.builder()
-            .oauthId("testOauthId")
-            .provider("testProvider")
-            .userRole(UserRole.GUEST)
-            .name("testUser")
-            .email(new Email("asdsadsad@gmail.com"))
-            .phoneNumber(new PhoneNumber("010-2312-1231"))
-            .profileImgUrl("urlurlrurlrurlurlurl")
-            .build();
-
-        return userRepository.save(user);
-    }
-
-    private Room createRoom() {
-        host = User.builder()
-            .oauthId("testOauth")
-            .provider("testProvider")
-            .userRole(UserRole.GUEST)
-            .name("testUser")
-            .email(new Email("asdsadsasdad@gmail.com"))
-            .profileImgUrl("urlurlrurlrurlurlurl")
-            .build();
-        userRepository.save(host);
-        Room room = Room.builder()
-            .name("별이 빛나는 밤")
-            .maxGuestNum(1)
-            .host(host)
-            .description("방 설명 입니다")
-            .address(new RoomAddress("00000", "창원", "의창구"))
-            .price(new Money(10_000))
-            .roomOption(new RoomOption(1, 1, 1))
-            .roomType(RoomType.APARTMENT)
-            .roomScope(RoomScope.PRIVATE)
-            .roomImages(List.of(createRoomImage()))
-            .build();
-
-        return roomRepository.save(room);
-    }
-
-    private RoomImage createRoomImage() {
-        return new RoomImage("aaa");
     }
 
     private Reservation createReservation(User guest, ReservationDate reservationDate) {

--- a/src/test/java/com/prgrms/amabnb/reservation/service/ReservationGuestServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/service/ReservationGuestServiceTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.reservation.service;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static java.time.LocalDate.*;
 import static org.assertj.core.api.Assertions.*;
@@ -12,8 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.prgrms.amabnb.common.vo.Email;
-import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.config.ApiTest;
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.amabnb.reservation.dto.request.ReservationDateRequest;
@@ -29,15 +28,9 @@ import com.prgrms.amabnb.reservation.exception.ReservationInvalidValueException;
 import com.prgrms.amabnb.reservation.exception.ReservationNotHavePermissionException;
 import com.prgrms.amabnb.reservation.repository.ReservationRepository;
 import com.prgrms.amabnb.room.entity.Room;
-import com.prgrms.amabnb.room.entity.RoomImage;
-import com.prgrms.amabnb.room.entity.RoomScope;
-import com.prgrms.amabnb.room.entity.RoomType;
-import com.prgrms.amabnb.room.entity.vo.RoomAddress;
-import com.prgrms.amabnb.room.entity.vo.RoomOption;
 import com.prgrms.amabnb.room.exception.RoomNotFoundException;
 import com.prgrms.amabnb.room.repository.RoomRepository;
 import com.prgrms.amabnb.user.entity.User;
-import com.prgrms.amabnb.user.entity.UserRole;
 import com.prgrms.amabnb.user.exception.UserNotFoundException;
 import com.prgrms.amabnb.user.repository.UserRepository;
 
@@ -63,8 +56,8 @@ class ReservationGuestServiceTest extends ApiTest {
 
     @BeforeEach
     void setUp() {
-        guest = userRepository.save(createUser());
-        host = createHost();
+        guest = userRepository.save(createUser("guest"));
+        host = userRepository.save(createUser("host"));
         room = roomRepository.save(createRoom(host));
     }
 
@@ -271,51 +264,6 @@ class ReservationGuestServiceTest extends ApiTest {
             .totalPrice(totalPrice)
             .roomId(roomId)
             .build();
-    }
-
-    private User createUser() {
-        return User.builder()
-            .oauthId("1")
-            .provider("kakao")
-            .name("아만드")
-            .email(new Email("aramnd@gmail.com"))
-            .userRole(UserRole.GUEST)
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private User createHost() {
-        User user = User.builder()
-            .oauthId("host")
-            .provider("host")
-            .userRole(UserRole.HOST)
-            .name("host")
-            .email(new Email("host@gmail.com"))
-            .profileImgUrl("urlurlrurlrurlurlurl")
-            .build();
-
-        return userRepository.save(user);
-    }
-
-    private Room createRoom(User host) {
-        Room room = Room.builder()
-            .name("별이 빛나는 밤")
-            .maxGuestNum(10)
-            .description("방 설명 입니다")
-            .address(new RoomAddress("00000", "창원", "의창구"))
-            .price(new Money(10_000))
-            .roomOption(new RoomOption(1, 1, 1))
-            .roomType(RoomType.APARTMENT)
-            .roomScope(RoomScope.PRIVATE)
-            .host(host)
-            .roomImages(List.of(createRoomImage()))
-            .build();
-
-        return room;
-    }
-
-    private RoomImage createRoomImage() {
-        return new RoomImage("aaa");
     }
 
     private CreateReservationRequest createReservationByDay(int day) {

--- a/src/test/java/com/prgrms/amabnb/reservation/service/ReservationHostServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/service/ReservationHostServiceTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.reservation.service;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static java.time.LocalDate.*;
 import static org.assertj.core.api.Assertions.*;
@@ -12,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.prgrms.amabnb.common.vo.Email;
 import com.prgrms.amabnb.common.vo.Money;
 import com.prgrms.amabnb.config.ApiTest;
 import com.prgrms.amabnb.reservation.dto.request.SearchReservationsRequest;
@@ -25,14 +25,8 @@ import com.prgrms.amabnb.reservation.exception.ReservationNotHavePermissionExcep
 import com.prgrms.amabnb.reservation.exception.ReservationStatusException;
 import com.prgrms.amabnb.reservation.repository.ReservationRepository;
 import com.prgrms.amabnb.room.entity.Room;
-import com.prgrms.amabnb.room.entity.RoomImage;
-import com.prgrms.amabnb.room.entity.RoomScope;
-import com.prgrms.amabnb.room.entity.RoomType;
-import com.prgrms.amabnb.room.entity.vo.RoomAddress;
-import com.prgrms.amabnb.room.entity.vo.RoomOption;
 import com.prgrms.amabnb.room.repository.RoomRepository;
 import com.prgrms.amabnb.user.entity.User;
-import com.prgrms.amabnb.user.entity.UserRole;
 import com.prgrms.amabnb.user.repository.UserRepository;
 
 class ReservationHostServiceTest extends ApiTest {
@@ -56,8 +50,8 @@ class ReservationHostServiceTest extends ApiTest {
 
     @BeforeEach
     void setUp() {
-        guest = userRepository.save(createGuest());
-        host = userRepository.save(createHost());
+        guest = userRepository.save(createUser("guest"));
+        host = userRepository.save(createUser("host"));
         room = roomRepository.save(createRoom(host));
         reservationId = reservationRepository.save(createReservation(room, guest)).getId();
     }
@@ -172,46 +166,4 @@ class ReservationHostServiceTest extends ApiTest {
             .build();
     }
 
-    private User createGuest() {
-        return User.builder()
-            .oauthId("1")
-            .provider("kakao")
-            .name("아만드")
-            .email(new Email("aramnd@gmail.com"))
-            .userRole(UserRole.GUEST)
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private User createHost() {
-        return User.builder()
-            .oauthId("host")
-            .provider("host")
-            .userRole(UserRole.HOST)
-            .name("host")
-            .email(new Email("host@gmail.com"))
-            .profileImgUrl("urlurlrurlrurlurlurl")
-            .build();
-    }
-
-    private Room createRoom(User host) {
-        Room room = Room.builder()
-            .name("별이 빛나는 밤")
-            .maxGuestNum(10)
-            .description("방 설명 입니다")
-            .address(new RoomAddress("00000", "창원", "의창구"))
-            .price(new Money(10_000))
-            .roomOption(new RoomOption(1, 1, 1))
-            .roomType(RoomType.APARTMENT)
-            .roomScope(RoomScope.PRIVATE)
-            .host(host)
-            .roomImages(List.of(createRoomImage()))
-            .build();
-
-        return room;
-    }
-
-    private RoomImage createRoomImage() {
-        return new RoomImage("aaa");
-    }
 }

--- a/src/test/java/com/prgrms/amabnb/reservation/service/ReservationHostServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/service/ReservationHostServiceTest.java
@@ -144,17 +144,6 @@ class ReservationHostServiceTest extends ApiTest {
         );
     }
 
-    private Reservation createReservation(Room room, User guest) {
-        return Reservation.builder()
-            .room(room)
-            .guest(guest)
-            .totalPrice(new Money(20_000))
-            .totalGuest(1)
-            .reservationDate(new ReservationDate(now(), now().plusDays(1L)))
-            .reservationStatus(PENDING)
-            .build();
-    }
-
     private Reservation createReservationByDay(int day) {
         return Reservation.builder()
             .room(room)

--- a/src/test/java/com/prgrms/amabnb/security/oauth/OAuthServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/security/oauth/OAuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.security.oauth;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
@@ -38,13 +39,7 @@ class OAuthServiceTest {
 
         @BeforeEach
         void MOCK_SET() {
-            givenUserProfile = UserProfile.builder()
-                .oauthId("something oauth id")
-                .provider("kakao")
-                .name("subin")
-                .email("armand@prgrms.com")
-                .profileImgUrl("something imageurl")
-                .build();
+            givenUserProfile = createUserProfile("test");
             givenToken = new TokenResponse("accessToekn", "refreshToken");
             givenRegisteredUser = new UserRegisterResponse(1L, "ROLE_USER");
 

--- a/src/test/java/com/prgrms/amabnb/user/api/UserApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/user/api/UserApiTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.user.api;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -10,15 +11,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.prgrms.amabnb.common.vo.Email;
 import com.prgrms.amabnb.config.ApiTest;
 import com.prgrms.amabnb.token.dto.TokenResponse;
 import com.prgrms.amabnb.token.service.TokenService;
 import com.prgrms.amabnb.user.dto.response.UserRegisterResponse;
 import com.prgrms.amabnb.user.entity.User;
-import com.prgrms.amabnb.user.entity.UserRole;
 import com.prgrms.amabnb.user.repository.UserRepository;
 import com.prgrms.amabnb.user.service.UserService;
 
@@ -35,18 +33,8 @@ class UserApiTest extends ApiTest {
     User givenUser;
 
     @BeforeEach
-    @Transactional
     void setUp() {
-        var user = User.builder()
-            .name("su")
-            .userRole(UserRole.GUEST)
-            .provider("kakao")
-            .oauthId("oauthId")
-            .email(new Email("kimziou77@naver.com"))
-            .profileImgUrl("something url")
-            .build();
-
-        givenUser = userRepository.save(user);
+        givenUser = userRepository.save(createUser("test"));
         givenToken = tokenService.createToken(
             new UserRegisterResponse(givenUser.getId(), givenUser.getUserRole().getGrantedAuthority()));
     }

--- a/src/test/java/com/prgrms/amabnb/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/amabnb/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.amabnb.user.service;
 
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -14,8 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.prgrms.amabnb.common.vo.Email;
-import com.prgrms.amabnb.security.oauth.UserProfile;
 import com.prgrms.amabnb.user.dto.response.MyUserInfoResponse;
 import com.prgrms.amabnb.user.entity.User;
 import com.prgrms.amabnb.user.entity.UserRole;
@@ -31,37 +30,15 @@ class UserServiceTest {
     @InjectMocks
     private UserService userService;
 
-    private UserProfile createUserProfile() {
-        return UserProfile.builder()
-            .oauthId("1")
-            .provider("kakao")
-            .name("아만드")
-            .email("asdasd@gmail.com")
-            .profileImgUrl("url")
-            .build();
-    }
-
-    private User createUser(long userId, UserRole userRole) {
-        return User.builder()
-            .id(userId)
-            .oauthId("1")
-            .provider("kakao")
-            .name("아만드")
-            .email(new Email("aramnd@gmail.com"))
-            .userRole(userRole)
-            .profileImgUrl("url")
-            .build();
-    }
-
     @Nested
     class register {
         @DisplayName("저장된 유저가 없을 경우 유저를 저장하고 유저 정보를 반환한다.")
         @Test
         void register_NotSavedUser() {
             // given
-            var userProfile = createUserProfile();
+            var userProfile = createUserProfile("test");
             given(userRepository.findByOauthId(any(String.class))).willReturn(Optional.empty());
-            given(userRepository.save(any(User.class))).willReturn(createUser(1L, UserRole.GUEST));
+            given(userRepository.save(any(User.class))).willReturn(createUserWithId("test"));
 
             // when
             var registerResponse = userService.register(userProfile);
@@ -77,17 +54,16 @@ class UserServiceTest {
         @Test
         void register_SavedUser() {
             // given
-            var userProfile = createUserProfile();
-            given(userRepository.findByOauthId(any(String.class))).willReturn(
-                Optional.of(createUser(2L, UserRole.HOST)));
+            var userProfile = createUserProfile("test");
+            given(userRepository.findByOauthId(any(String.class))).willReturn(Optional.of(createUserWithId("test")));
 
             // when
             var registerResponse = userService.register(userProfile);
 
             // then
             assertAll(
-                () -> assertThat(registerResponse.id()).isEqualTo(2L),
-                () -> assertThat(registerResponse.role()).isEqualTo("ROLE_HOST")
+                () -> assertThat(registerResponse.id()).isEqualTo(1L),
+                () -> assertThat(registerResponse.role()).isEqualTo("ROLE_GUEST")
             );
         }
     }
@@ -95,7 +71,7 @@ class UserServiceTest {
     @Nested
     @DisplayName("유저 정보를 조회할 수 있다 #45")
     class FindUserInfo {
-        User givenUser = createUser(1L, UserRole.GUEST);
+        User givenUser = createUserWithId("test");
 
         @DisplayName("Principle 에서 userId를 파싱해 유저정보를 db 에서 가져온다")
         @Test
@@ -129,7 +105,7 @@ class UserServiceTest {
     @Nested
     @DisplayName("유저는 서비스 탈퇴를 할 수 있다 #46")
     class ExitUser {
-        User givenUser = createUser(1L, UserRole.GUEST);
+        User givenUser = createUserWithId("test");
 
         @DisplayName("유저가 탈퇴하면 해당하는 유저 정보를 파기한다")
         @Test


### PR DESCRIPTION
## 개요
- 테스트 픽스처 클래스 구현 

## 작업사항
<img width="522" alt="스크린샷 2022-07-05 오후 1 27 48" src="https://user-images.githubusercontent.com/65746780/177249409-baf23887-3e7a-43c8-b147-405b80c25bd9.png">

- 중복사용되어 지는 유저, 숙소, 예약을 모아놨습니다. 
- 추가적으로 중복되는 부분이 있다면 작성하시면 됩니다!! 🔥

## 변경로직
<img width="766" alt="스크린샷 2022-07-05 오후 1 30 06" src="https://user-images.githubusercontent.com/65746780/177249639-80548d4f-40ec-4ad2-a531-9ffc938d7bae.png">

- ApiTest에 숙소 등록, 예약 요청을 넣어놨습니다. 테스트시 활용하시면 됩니다. 
- 로그인 요청은 파라미터로 UserProfile을 받도록 했었는데 name만 받아도 될 것 같아 하나 더 만들어 놨습니다. 
  **_- name만 받도록 모두 수정해주세요!_**  

## 질문
- 유저를 만들 때 그냥 호스트용, 게스트용으로 만드는 데 더 깔끔해보이는 데 어떻게 생각하시나요?
  - 굳이 이름을 받아서 구분하지 말고 만들어 놓아도 좋을 것 같긴합니다. 
  - 일단 이름을 받도록 구현해놨습니다.
- 질문은 아니지만 테스트 폴더 구조를 바꿔야 할 것 같은데 이거는 기능 머지가 다 되면 하겠습니다. 아니면 충돌 날 것 같아요... 😂 

## 기타
resolves #48 
