### PR TITLE
[#85] feat: Rest Docs 기본 설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id 'org.asciidoctor.convert' version '1.5.8'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
     // queryDsl
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
@@ -22,7 +22,15 @@ repositories {
 }
 
 ext {
-    set('snippetsDir', file("build/generated-snippets"))
+    snippetsDir = file('build/generated-snippets')
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath // queryDsl
+    asciidoctorExt //asciidoc
 }
 
 dependencies {
@@ -50,8 +58,10 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     // test
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.6.RELEASE'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation "org.springframework.restdocs:spring-restdocs-mockmvc"
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.google.guava:guava:31.1-jre'
 
@@ -60,14 +70,42 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 }
 
-tasks.named('test') {
+test {
     outputs.dir snippetsDir
     useJUnitPlatform()
 }
 
-tasks.named('asciidoctor') {
+asciidoctor {
+    inProcess = JAVA_EXEC
+    forkOptions {
+        jvmArgs("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED")
+    }
+    configurations "asciidoctorExt"
     inputs.dir snippetsDir
     dependsOn test
+    baseDirFollowsSourceFile()
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+bootJar {
+    dependsOn asciidoctor
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'BOOT-INF/classes/static/docs'
+    }
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }
 
 
@@ -83,12 +121,5 @@ sourceSets {
 }
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
-}
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath // queryDsl
-    asciidoctorExt //asciidoc
 }
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,17 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:docinfo: shared-head
+
+= Amabnb
+
+include::user.adoc[]
+include::token.adoc[]
+include::reservation_guest.adoc[]
+include::reservation_host.adoc[]

--- a/src/docs/asciidoc/reservation_guest.adoc
+++ b/src/docs/asciidoc/reservation_guest.adoc
@@ -1,0 +1,126 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:docinfo: shared-head
+
+
+== 예약 게스트 API
+
+=== 공통
+
+모든 예약 게스트 요청은 JWT access token 이 필요합니다.
+
+include::{snippets}/reservation-guest-api-test/create_reservation/request-headers.adoc[]
+
+=== 예약 생성
+
+==== Request
+
+include::{snippets}/reservation-guest-api-test/create_reservation/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-guest-api-test/create_reservation/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-guest-api-test/create_reservation/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-guest-api-test/create_reservation/http-response.adoc[]
+
+=== 예약 불가능 날짜 조회
+
+==== Request
+
+include::{snippets}/reservation-guest-api-test/get-reservation-dates/request-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-guest-api-test/get-reservation-dates/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-guest-api-test/get-reservation-dates/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-guest-api-test/get-reservation-dates/http-response.adoc[]
+
+=== 예약 단건 조회
+
+==== Request
+
+include::{snippets}/reservation-guest-api-test/get-reservation/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-guest-api-test/get-reservation/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-guest-api-test/get-reservation/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-guest-api-test/get-reservation/http-response.adoc[]
+
+=== 예약 다건 조회
+
+==== Request
+
+include::{snippets}/reservation-guest-api-test/get-reservations/request-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-guest-api-test/get-reservations/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-guest-api-test/get-reservations/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-guest-api-test/get-reservations/http-response.adoc[]
+
+=== 예약 수정
+
+==== Request
+
+include::{snippets}/reservation-guest-api-test/modify-reservation/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-guest-api-test/modify-reservation/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-guest-api-test/modify-reservation/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-guest-api-test/modify-reservation/http-response.adoc[]
+
+=== 예약 취소
+
+==== Request
+
+include::{snippets}/reservation-guest-api-test/cancel/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-guest-api-test/cancel/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-guest-api-test/cancel/http-response.adoc[]
+

--- a/src/docs/asciidoc/reservation_host.adoc
+++ b/src/docs/asciidoc/reservation_host.adoc
@@ -1,0 +1,90 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:docinfo: shared-head
+
+
+== 예약 호스트 API
+
+=== 공통
+
+모든 예약 호스트 요청은 JWT access token 이 필요합니다.
+
+include::{snippets}/reservation-guest-api-test/create_reservation/request-headers.adoc[]
+
+=== 예약 단건 조회
+
+==== Request
+
+include::{snippets}/reservation-host-api-test/get-reservation/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-host-api-test/get-reservation/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-host-api-test/get-reservation/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-host-api-test/get-reservation/http-response.adoc[]
+
+=== 예약 다건 조회
+
+==== Request
+
+include::{snippets}/reservation-host-api-test/get-reservations/request-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-host-api-test/get-reservations/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-host-api-test/get-reservations/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-host-api-test/get-reservations/http-response.adoc[]
+
+=== 예약 승인
+
+==== Request
+
+include::{snippets}/reservation-host-api-test/approve-reservation/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-host-api-test/approve-reservation/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/reservation-host-api-test/approve-reservation/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-host-api-test/approve-reservation/http-response.adoc[]
+
+=== 예약 취소
+
+==== Request
+
+include::{snippets}/reservation-host-api-test/cancel/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/reservation-host-api-test/cancel/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/reservation-host-api-test/cancel/http-response.adoc[]
+

--- a/src/docs/asciidoc/token.adoc
+++ b/src/docs/asciidoc/token.adoc
@@ -1,0 +1,51 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:docinfo: shared-head
+
+
+== 토큰 API
+
+=== 공통
+
+모든 토큰 요청은 JWT access token 이 필요합니다.
+
+include::{snippets}/refresh-access-token/refresh-access-token_success/request-headers.adoc[]
+
+=== access 토큰 재발급
+
+==== Request
+
+include::{snippets}/refresh-access-token/refresh-access-token_success/request-fields.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/refresh-access-token/refresh-access-token_success/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/refresh-access-token/refresh-access-token_success/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/refresh-access-token/refresh-access-token_success/http-response.adoc[]
+
+=== refresh 토큰 삭제 (로그아웃)
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/delete-refresh-token/delete-refresh-token/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/delete-refresh-token/delete-refresh-token/http-response.adoc[]

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,0 +1,68 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:docinfo: shared-head
+
+
+== 유저 API
+
+=== 공통
+
+로그인을 제외한 모든 유저 요청은 JWT access token 이 필요합니다.
+
+include::{snippets}/delete-account/delete-user/request-headers.adoc[]
+
+=== 카카오 로그인
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/user-api-test/login-document/http-request.adoc[]
+
+==== Response
+
+카카오 로그인 창
+
+===== Response HTTP Example
+
+include::{snippets}/user-api-test/login-document/http-response.adoc[]
+
+로그인 완료 시 토큰 응답
+
+=== 정보 조회
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/my-page/user-page/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/my-page/user-page/response-fields.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/my-page/user-page/http-response.adoc[]
+
+=== 탈퇴
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/delete-account/delete-user/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/delete-account/delete-user/http-response.adoc[]
+

--- a/src/main/java/com/prgrms/amabnb/security/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/amabnb/security/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
 
             .authorizeHttpRequests()
             .antMatchers("/tokens").permitAll()
+            .antMatchers("/docs/**").permitAll()
+            .antMatchers("/favicon.ico").permitAll()
             .anyRequest().authenticated()
             .and()
 

--- a/src/main/java/com/prgrms/amabnb/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/amabnb/security/jwt/JwtAuthenticationFilter.java
@@ -25,11 +25,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getRequestURI().endsWith("token") || request.getRequestURI().contains("login/oauth2/code");
-    }
-
-    @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain)
         throws ServletException, IOException {
 

--- a/src/main/java/com/prgrms/amabnb/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/amabnb/security/jwt/JwtAuthenticationFilter.java
@@ -25,6 +25,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getRequestURI().endsWith("tokens");
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain)
         throws ServletException, IOException {
 

--- a/src/main/java/com/prgrms/amabnb/user/api/UserApi.java
+++ b/src/main/java/com/prgrms/amabnb/user/api/UserApi.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prgrms.amabnb.common.model.ApiResponse;
 import com.prgrms.amabnb.security.jwt.JwtAuthentication;
 import com.prgrms.amabnb.user.dto.response.MyUserInfoResponse;
 import com.prgrms.amabnb.user.service.UserService;
@@ -21,8 +22,8 @@ public class UserApi {
     private final UserService userService;
 
     @GetMapping("/me")
-    ResponseEntity<MyUserInfoResponse> myPage(@AuthenticationPrincipal JwtAuthentication user) {
-        return ResponseEntity.ok().body(userService.findUserInfo(user.id()));
+    ResponseEntity<ApiResponse<MyUserInfoResponse>> myPage(@AuthenticationPrincipal JwtAuthentication user) {
+        return ResponseEntity.ok().body(new ApiResponse<>(userService.findUserInfo(user.id())));
     }
 
     @DeleteMapping("/me")

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -29,7 +29,7 @@ spring:
             client-secret: test
             scope: test
             redirect-uri: test
-            authorization-grant-type: test
+            authorization-grant-type: authorization_code
         provider:
           kakao:
             authorization_uri: test

--- a/src/test/java/com/prgrms/amabnb/config/ApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/config/ApiTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -35,7 +34,6 @@ import com.prgrms.amabnb.security.oauth.OAuthService;
 
 @Import(InfraConfig.class)
 @SpringBootTest
-@AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class ApiTest {
 

--- a/src/test/java/com/prgrms/amabnb/config/ApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/config/ApiTest.java
@@ -3,53 +3,80 @@ package com.prgrms.amabnb.config;
 import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.headers.RequestHeadersSnippet;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.amabnb.common.exception.ErrorResponse;
 import com.prgrms.amabnb.config.util.DatabaseCleanup;
 import com.prgrms.amabnb.reservation.dto.request.CreateReservationRequest;
 import com.prgrms.amabnb.room.dto.request.CreateRoomRequest;
 import com.prgrms.amabnb.security.oauth.OAuthService;
-import com.prgrms.amabnb.security.oauth.UserProfile;
 
 @Import(InfraConfig.class)
 @SpringBootTest
-@AutoConfigureMockMvc
 @AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
 public abstract class ApiTest {
 
     static {
         System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
     }
 
-    @Autowired
     protected MockMvc mockMvc;
-
     @Autowired
     protected ObjectMapper objectMapper;
-
     @Autowired
     protected OAuthService oAuthService;
-
     @Autowired
     protected DatabaseCleanup databaseCleanup;
+
+    protected RestDocumentationResultHandler document;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+        this.document = document(
+            "{class-name}/{method-name}",
+            preprocessRequest(
+                modifyUris()
+                    .scheme("http")
+                    .host("54.180.129.133")
+                    .removePort(),
+                prettyPrint()),
+            preprocessResponse(removeHeaders("Transfer-Encoding",
+                    "Date",
+                    "Keep-Alive",
+                    "Connection"
+                ),
+                prettyPrint())
+        );
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply(documentationConfiguration(provider))
+            .apply(springSecurity())
+            .alwaysDo(document)
+            .alwaysDo(print())
+            .build();
+    }
 
     @AfterEach
     void tearDown() {
@@ -62,12 +89,8 @@ public abstract class ApiTest {
         );
     }
 
-    protected String 로그인_요청(UserProfile userProfile) {
-        return "Bearer" + oAuthService.register(userProfile).accessToken();
-    }
-
     protected String 로그인_요청(String name) {
-        return "Bearer" + oAuthService.register(createUserProfile(name)).accessToken();
+        return "Bearer " + oAuthService.register(createUserProfile(name)).accessToken();
     }
 
     protected MockHttpServletResponse 예약_요청(String accessToken, CreateReservationRequest request) throws Exception {
@@ -92,10 +115,6 @@ public abstract class ApiTest {
     protected Long extractId(MockHttpServletResponse response) {
         String[] locations = response.getHeader("Location").split("/");
         return Long.valueOf(locations[locations.length - 1]);
-    }
-
-    protected ErrorResponse extractErrorResponse(MockHttpServletResponse response) throws IOException {
-        return objectMapper.readValue(response.getContentAsString(StandardCharsets.UTF_8), ErrorResponse.class);
     }
 
     protected String toJson(Object object) throws JsonProcessingException {

--- a/src/test/java/com/prgrms/amabnb/config/util/DocumentFormatGenerator.java
+++ b/src/test/java/com/prgrms/amabnb/config/util/DocumentFormatGenerator.java
@@ -1,0 +1,11 @@
+package com.prgrms.amabnb.config.util;
+
+import static org.springframework.restdocs.snippet.Attributes.*;
+
+import org.springframework.restdocs.snippet.Attributes;
+
+public class DocumentFormatGenerator {
+    public static Attributes.Attribute getDateFormat() {
+        return key("format").value("yyyy-MM-dd");
+    }
+}

--- a/src/test/java/com/prgrms/amabnb/reservation/api/ReservationHostApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/reservation/api/ReservationHostApiTest.java
@@ -1,12 +1,12 @@
 package com.prgrms.amabnb.reservation.api;
 
+import static com.prgrms.amabnb.config.util.DocumentFormatGenerator.*;
 import static com.prgrms.amabnb.config.util.Fixture.*;
 import static com.prgrms.amabnb.reservation.entity.ReservationStatus.*;
 import static java.time.LocalDate.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -47,7 +47,7 @@ class ReservationHostApiTest extends ApiTest {
     void approveReservation() throws Exception {
         // given
         MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청("guest"),
-            createReservationRequest(3, 300_000, roomId));
+            createReservationRequest(roomId));
         Long reservationId = extractId(ReservationResponseForGuest);
 
         // when
@@ -55,15 +55,17 @@ class ReservationHostApiTest extends ApiTest {
                 .header(HttpHeaders.AUTHORIZATION, hostAccessToken)
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
-            .andDo(document("reservation-host-approve",
+            .andDo(document.document(
                 tokenRequestHeader(),
                 pathParameters(
                     parameterWithName("reservationId").description("예약 아이디")
                 ),
                 responseFields(
                     fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("예약 아이디"),
-                    fieldWithPath("data.checkIn").type(JsonFieldType.STRING).description("체크인 날짜"),
-                    fieldWithPath("data.checkOut").type(JsonFieldType.STRING).description("체크아웃 날짜"),
+                    fieldWithPath("data.checkIn").type(JsonFieldType.STRING).attributes(getDateFormat())
+                        .description("체크인 날짜"),
+                    fieldWithPath("data.checkOut").type(JsonFieldType.STRING).attributes(getDateFormat())
+                        .description("체크아웃 날짜"),
                     fieldWithPath("data.totalGuest").type(JsonFieldType.NUMBER).description("총 인원수"),
                     fieldWithPath("data.totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
                     fieldWithPath("data.reservationStatus").type(JsonFieldType.STRING).description("예약 상태")
@@ -82,10 +84,10 @@ class ReservationHostApiTest extends ApiTest {
 
     @DisplayName("호스트가 예약을 취소한다. 204 - NO CONTENT")
     @Test
-    void cancelByHost() throws Exception {
+    void cancel() throws Exception {
         // given
         MockHttpServletResponse ReservationResponseForGuest = 예약_요청(로그인_요청("guest"),
-            createReservationRequest(3, 300_000, roomId));
+            createReservationRequest(roomId));
         Long reservationId = extractId(ReservationResponseForGuest);
 
         // when
@@ -93,7 +95,7 @@ class ReservationHostApiTest extends ApiTest {
                 .header(HttpHeaders.AUTHORIZATION, hostAccessToken)
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
-            .andDo(document("reservation-host-approve",
+            .andDo(document.document(
                 tokenRequestHeader(),
                 pathParameters(
                     parameterWithName("reservationId").description("예약 아이디")
@@ -109,7 +111,7 @@ class ReservationHostApiTest extends ApiTest {
     void getReservation() throws Exception {
         // given
         MockHttpServletResponse createResponse = 예약_요청(로그인_요청("guest"),
-            createReservationRequest(3, 300_000, roomId));
+            createReservationRequest(roomId));
         Long reservationId = extractId(createResponse);
 
         // when
@@ -128,15 +130,17 @@ class ReservationHostApiTest extends ApiTest {
             )
 
             // docs
-            .andDo(document("reservation-host-findOne",
+            .andDo(document.document(
                 tokenRequestHeader(),
                 pathParameters(
                     parameterWithName("reservationId").description("예약 아이디")
                 ),
                 responseFields(
                     fieldWithPath("data.reservation.id").type(JsonFieldType.NUMBER).description("아이디"),
-                    fieldWithPath("data.reservation.checkIn").type(JsonFieldType.STRING).description("체크인 날짜"),
-                    fieldWithPath("data.reservation.checkOut").type(JsonFieldType.STRING).description("체크아웃 날짜"),
+                    fieldWithPath("data.reservation.checkIn").type(JsonFieldType.STRING).attributes(getDateFormat())
+                        .description("체크인 날짜"),
+                    fieldWithPath("data.reservation.checkOut").type(JsonFieldType.STRING).attributes(getDateFormat())
+                        .description("체크아웃 날짜"),
                     fieldWithPath("data.reservation.totalGuest").type(JsonFieldType.NUMBER).description("총 인원수"),
                     fieldWithPath("data.reservation.totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
                     fieldWithPath("data.reservation.reservationStatus").type(JsonFieldType.STRING).description("예약 상태"),
@@ -179,7 +183,7 @@ class ReservationHostApiTest extends ApiTest {
             )
 
             // docs
-            .andDo(document("reservation-host-find",
+            .andDo(document.document(
                 tokenRequestHeader(),
                 requestParameters(
                     parameterWithName("pageSize").description("페이지 사이즈"),
@@ -188,8 +192,10 @@ class ReservationHostApiTest extends ApiTest {
                 ),
                 responseFields(
                     fieldWithPath("data[].reservation.id").type(JsonFieldType.NUMBER).description("아이디"),
-                    fieldWithPath("data[].reservation.checkIn").type(JsonFieldType.STRING).description("체크인 날짜"),
-                    fieldWithPath("data[].reservation.checkOut").type(JsonFieldType.STRING).description("체크아웃 날짜"),
+                    fieldWithPath("data[].reservation.checkIn").type(JsonFieldType.STRING).attributes(getDateFormat())
+                        .description("체크인 날짜"),
+                    fieldWithPath("data[].reservation.checkOut").type(JsonFieldType.STRING).attributes(getDateFormat())
+                        .description("체크아웃 날짜"),
                     fieldWithPath("data[].reservation.totalGuest").type(JsonFieldType.NUMBER).description("총 인원수"),
                     fieldWithPath("data[].reservation.totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
                     fieldWithPath("data[].reservation.reservationStatus").type(JsonFieldType.STRING)
@@ -208,12 +214,12 @@ class ReservationHostApiTest extends ApiTest {
                 )));
     }
 
-    private CreateReservationRequest createReservationRequest(int totalGuest, int totalPrice, Long roomId) {
+    private CreateReservationRequest createReservationRequest(Long roomId) {
         return CreateReservationRequest.builder()
             .checkIn(LocalDate.now())
             .checkOut(LocalDate.now().plusDays(3L))
-            .totalGuest(totalGuest)
-            .totalPrice(totalPrice)
+            .totalGuest(3)
+            .totalPrice(300000)
             .roomId(roomId)
             .build();
     }

--- a/src/test/java/com/prgrms/amabnb/review/api/ReviewApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/review/api/ReviewApiTest.java
@@ -175,7 +175,7 @@ class ReviewApiTest extends ApiTest {
             var errorMessage = "리뷰에 대한 권한이 존재하지 않습니다.";
             assertThat(reviewRepository.count()).isOne();
 
-            var illegalToken = 로그인_요청(createUserProfile("illegal-user"));
+            var illegalToken = 로그인_요청("illegal-user");
 
             when_리뷰_삭제(illegalToken, givenReview.getId())
                 .andExpect(status().isBadRequest())
@@ -214,7 +214,7 @@ class ReviewApiTest extends ApiTest {
         @DisplayName("본인이 작성하지 않은 리뷰는 수정할 수 없다")
         void noPermission() throws Exception {
             var errorMessage = "리뷰에 대한 권한이 존재하지 않습니다.";
-            var illegalToken = 로그인_요청(createUserProfile("illegal-user"));
+            var illegalToken = 로그인_요청("illegal-user");
 
             when_리뷰_수정(illegalToken, givenReview.getId(), givenEditDto)
                 .andExpect(status().isBadRequest())

--- a/src/test/java/com/prgrms/amabnb/room/api/HostRoomApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/room/api/HostRoomApiTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.amabnb.room.api;
 
-import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -26,7 +25,7 @@ class HostRoomApiTest extends ApiTest {
     @Test
     @DisplayName("숙소 등록 성공 테스트")
     void createRoom() throws Exception {
-        String accessToken = 로그인_요청();
+        String accessToken = 로그인_요청("host");
         CreateRoomRequest createRoomRequest = createCreateRoomRequest();
 
         mockMvc.perform(post("/host/rooms")
@@ -57,7 +56,7 @@ class HostRoomApiTest extends ApiTest {
     @DisplayName("호스트는 자신이 등록한 방 목록을 가져온다")
     void getHostRooms() throws Exception {
         //given
-        String accessToken = 로그인_요청();
+        String accessToken = 로그인_요청("host");
         saveRoom(accessToken);
         saveRoom(accessToken);
 
@@ -90,7 +89,7 @@ class HostRoomApiTest extends ApiTest {
     void modifyTest() throws Exception {
         //given
         ModifyRoomRequest modifyRequest = createModifyRequest();
-        String accessToken = 로그인_요청();
+        String accessToken = 로그인_요청("host");
         Long roomId = saveRoom(accessToken);
 
         // when,then
@@ -131,7 +130,7 @@ class HostRoomApiTest extends ApiTest {
     @DisplayName("Request 하나라도 값이 없다면 수정이 불가능하다")
     void invalidRequestModifyTest() throws Exception {
         //given
-        String accessToken = 로그인_요청();
+        String accessToken = 로그인_요청("host");
         Long roomId = saveRoom(accessToken);
 
         ModifyRoomRequest modifyRequest = ModifyRoomRequest.builder()
@@ -150,10 +149,6 @@ class HostRoomApiTest extends ApiTest {
             .andExpect(status().isBadRequest());
         //then
 
-    }
-
-    private String 로그인_요청() {
-        return "Bearer" + oAuthService.register(createUserProfile("아만드")).accessToken();
     }
 
     private Long saveRoom(String accessToken) throws Exception {

--- a/src/test/java/com/prgrms/amabnb/room/api/HostRoomApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/room/api/HostRoomApiTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.amabnb.room.api;
 
-import static com.prgrms.amabnb.common.fixture.ReviewFixture.*;
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -34,8 +34,7 @@ class HostRoomApiTest extends ApiTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(createRoomRequest)))
             .andExpect(status().isCreated())
-            .andDo(print())
-            .andDo(document("room-create",
+            .andDo(document.document(
                 requestFields(
                     fieldWithPath("name").type(JsonFieldType.STRING).description("숙소 이름"),
                     fieldWithPath("price").type(JsonFieldType.NUMBER).description("1박 가격"),
@@ -67,7 +66,7 @@ class HostRoomApiTest extends ApiTest {
                 .header(HttpHeaders.AUTHORIZATION, accessToken))
             .andExpect(status().isOk())
             .andDo(print())
-            .andDo(document("host-rooms",
+            .andDo(document.document(
                 responseFields(
                     fieldWithPath("data[].name").type(JsonFieldType.STRING).description("숙소 이름"),
                     fieldWithPath("data[].price").type(JsonFieldType.NUMBER).description("1박 가격"),

--- a/src/test/java/com/prgrms/amabnb/room/api/RoomApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/room/api/RoomApiTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.amabnb.room.api;
 
-import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -31,7 +30,7 @@ class RoomApiTest extends ApiTest {
     @DisplayName("필터 검색을 할 수 있다.")
     void filterSearchTest() throws Exception {
         //given
-        String accessToken = 로그인_요청();
+        String accessToken = 로그인_요청("host");
         saveRoom(accessToken);
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -79,7 +78,7 @@ class RoomApiTest extends ApiTest {
     @DisplayName("숙소 상세정보를 가져온다.")
     void getRoomDetail() throws Exception {
         //given
-        String accessToken = 로그인_요청();
+        String accessToken = 로그인_요청("host");
         Long roomId = saveRoom(accessToken);
 
         //when
@@ -143,11 +142,7 @@ class RoomApiTest extends ApiTest {
             .andDo(print());
 
     }
-
-    private String 로그인_요청() {
-        return "Bearer" + oAuthService.register(createUserProfile("아만드")).accessToken();
-    }
-
+    
     private Long saveRoom(String accessToken) throws Exception {
         String location = mockMvc.perform(post("/host/rooms")
                 .header(HttpHeaders.AUTHORIZATION, accessToken)

--- a/src/test/java/com/prgrms/amabnb/room/api/RoomApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/room/api/RoomApiTest.java
@@ -1,6 +1,6 @@
 package com.prgrms.amabnb.room.api;
 
-import static com.prgrms.amabnb.common.fixture.ReviewFixture.*;
+import static com.prgrms.amabnb.config.util.Fixture.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;

--- a/src/test/java/com/prgrms/amabnb/user/api/UserApiTest.java
+++ b/src/test/java/com/prgrms/amabnb/user/api/UserApiTest.java
@@ -1,8 +1,8 @@
 package com.prgrms.amabnb.user.api;
 
 import static com.prgrms.amabnb.config.util.Fixture.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 import com.prgrms.amabnb.config.ApiTest;
 import com.prgrms.amabnb.token.dto.TokenResponse;
@@ -39,20 +40,44 @@ class UserApiTest extends ApiTest {
             new UserRegisterResponse(givenUser.getId(), givenUser.getUserRole().getGrantedAuthority()));
     }
 
+    @DisplayName("카카오 로그인 요청 시 카카오 로그인 창을 응답한다.")
+    @Test
+    void loginDocument() throws Exception {
+        // when
+        mockMvc.perform(post("/oauth2/authorization/kakao"))
+            .andExpect(status().is3xxRedirection())
+
+            // then
+            .andDo(document.document(
+            ));
+    }
+
     @Nested
     @DisplayName("유저는 본인의 정보를 확인할 수 있다 #45")
     class MyPage {
         @Test
         void userPage() throws Exception {
+            // when
             mockMvc.perform(get("/me")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenToken.accessToken()))
-                .andExpect(handler().methodName("myPage"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("name").value(givenUser.getName()))
-                .andExpect(jsonPath("email").value(givenUser.getEmail().getValue()))
-                .andExpect(jsonPath("profileImageUrl").value(givenUser.getProfileImgUrl()))
-                .andExpect(jsonPath("role").value(givenUser.getUserRole().getGrantedAuthority()))
-                .andDo(print());
+
+                // then
+                .andExpectAll(
+                    handler().methodName("myPage"),
+                    status().isOk(),
+                    jsonPath("data.name").value(givenUser.getName()),
+                    jsonPath("data.profileImageUrl").value(givenUser.getProfileImgUrl()),
+                    jsonPath("data.role").value(givenUser.getUserRole().getGrantedAuthority())
+                )
+
+                // docs
+                .andDo(document.document(
+                    responseFields(
+                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("이름"),
+                        fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
+                        fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING).description("프로필 이미지"),
+                        fieldWithPath("data.role").type(JsonFieldType.STRING).description("회원 권한")
+                    )));
         }
     }
 
@@ -63,9 +88,14 @@ class UserApiTest extends ApiTest {
         void deleteUser() throws Exception {
             mockMvc.perform(delete("/me")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenToken.accessToken()))
-                .andExpect(handler().methodName("deleteAccount"))
-                .andExpect(status().isNoContent())
-                .andDo(print());
+
+                .andExpectAll(
+                    handler().methodName("deleteAccount"),
+                    status().isNoContent()
+                )
+                .andDo(document.document(
+                    tokenRequestHeader()
+                ));
         }
     }
 }

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
@@ -1,0 +1,15 @@
+===== End Point
+{{path}}
+
+[cols="3,2,5,5"]
+===== Path Parameters
+|===
+|파라미터|양식|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}{{.}}{{/format}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,12 @@
+===== Request Fields
+|===
+|필드명|타입|양식|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}{{.}}{{/format}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
@@ -1,0 +1,12 @@
+[cols="3,2,5,5"]
+===== Request Parameters
+|===
+|파라미터|필수값|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
@@ -1,0 +1,13 @@
+[cols="5,3,5,5"]
+===== Response Data Fields
+|===
+|필드명|타입|양식|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}{{.}}{{/format}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
## 개요
- Rest Docs를 작성한다. 

## 작업사항
- build시 html 파일이 resources/static에 복사되도록 하였습니다. 
  - 17버전의 경우 복사하는 과정에서 권한문제가 생겨 forkOptions를 통해 해결했습니다. 
  - 참고 : [[Java 16] FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem](https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/597)    
-  위의 과정에서 html파일이 공식문서에는 `build/asciidoc/html5/`에 생긴다고 하던데 테스트해봤을 때 `build/docs/asciidoc/`에 생성되서 일단은 이에 맞춰 설정했습니다.
    - 이에 관해서는 좀 더 공부해봐야 할 것 같습니다. 
- `ApiTest`에서 mockMvc 설정과 RestDocs 설정을 자동으로 하지 않고 수동으로 하였습니다. 
  - rest docs에 대한  공통로직을 한 곳에서 처리하기 위해 진행하였습니다.
      - 공통 로직 : `prettyPrint`, `host 정보`, `불필요한 헤더값 제거`, `MockMvc print`, `document 이름` 
- custom snippet를 적용하였습니다.    
- 현재 유저, 예약, 토큰 API docs를 작성했습니다. 

## 변경로직
- 숙소 api 테스트 Fixture import 변경 
- `로그인_요청` 메서드 이름만 받도록 설정 

## 사용방법
- `document`로 작성한 부분을 `document.document`로 변경하시면 됩니다.
  - 문서 이름은 제거해주세요! 설정으로 인해 `{class-name}/{method-name}`으로 생성됩니다. 
- 날짜 양식을 적고 싶다면 `DocumentFormatGenerator`를 사용하시면 됩니다.   
- adoc을 양식에 맞게 작성 후 index.adoc에 include 시켜주세요!

## 기타
resolves #85
