### PR TITLE
[#109] fix: TokenApiTest 테스트 깨지는 현상 수정

### DIFF
--- a/src/main/java/com/prgrms/amabnb/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/amabnb/security/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getRequestURI().endsWith("tokens");
+        return request.getRequestURI().endsWith("tokens") && request.getMethod().equalsIgnoreCase("POST");
     }
 
     @Override


### PR DESCRIPTION
## 개요
- TokenApiTest 테스트 깨지는 현상 수정

## 작업사항
- 토큰 삭제시 jwt 필터 거치도록 수정
  - 거치지 않을 경우 Authentication이 null이 되기 때문에 `request.getMethod().equalsIgnoreCase("POST")` 조건 추가함으로써 토큰 재발급시에만 거치도록 수정하였습니다.
  
## 기타
resolves #109 
